### PR TITLE
docs(help): document RSS adapter in /help across all 9 locales

### DIFF
--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -657,6 +657,17 @@ company's public boards-api directly. Companies without a recognizable
 ATS are skipped (the **Active Companies** card on `/#/scan` shows them
 in gray with `○`).
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+Point the scanner at any job board that publishes an RSS/Atom feed (LaraJobs, WeWorkRemotely, RemoteOK, golangprojects, …) by adding an entry with `provider: rss` plus an `rss:` (or `feed_url:`) key — **no code changes**. The RSS adapter parses each `<item>` (CDATA + HTML entities, titles/companies tag-stripped), normalizes it to a job, and runs the same `title_filter` / `location_filter` + dedup + pipeline-append flow as ATS sources. **RSS** then appears as a selectable source in the `#/scan` filter dropdown. (web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/es.md
+++ b/docs/help/es.md
@@ -614,6 +614,17 @@ y consulta la boards-api pública de cada empresa directamente. Las
 empresas sin un ATS reconocible se omiten (la tarjeta **Active
 Companies** en `/#/scan` las muestra en gris con `○`).
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+Apunta el escáner a cualquier portal de empleo que publique un feed RSS/Atom (LaraJobs, WeWorkRemotely, RemoteOK, golangprojects, …) añadiendo una entrada con `provider: rss` y una clave `rss:` (o `feed_url:`) — **sin cambios de código**. El adaptador RSS analiza cada `<item>` (CDATA + entidades HTML, títulos/empresas sin etiquetas), lo normaliza a una oferta y aplica el mismo flujo `title_filter` / `location_filter` + dedup + añadir a pipeline que las fuentes ATS. Luego **RSS** aparece como fuente seleccionable en el desplegable de filtro de `#/scan`. (web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/fr.md
+++ b/docs/help/fr.md
@@ -685,6 +685,17 @@ boards-api publique de chaque entreprise directement. Les entreprises sans
 ATS reconnaissable sont ignorées (la carte **Active Companies** sur `/#/scan`
 les affiche en gris avec `○`).
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+Pointez le scanner vers n'importe quel site d'emploi publiant un flux RSS/Atom (LaraJobs, WeWorkRemotely, RemoteOK, golangprojects, …) en ajoutant une entrée avec `provider: rss` et une clé `rss:` (ou `feed_url:`) — **sans modification de code**. L'adaptateur RSS analyse chaque `<item>` (CDATA + entités HTML, titres/entreprises nettoyés des balises), le normalise en offre, et applique le même flux `title_filter` / `location_filter` + déduplication + ajout au pipeline que les sources ATS. **RSS** apparaît ensuite comme source sélectionnable dans le menu de filtre de `#/scan`. (web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/ja.md
+++ b/docs/help/ja.md
@@ -607,6 +607,17 @@ SmartRecruiters / Workday のエンドポイント)、`enabled: true|false`
 ATS を持たない企業はスキップされます (`/#/scan` の **Active
 Companies** カードがグレー `○` で表示します)。
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+RSS/Atom フィードを公開している任意の求人ボード（LaraJobs、WeWorkRemotely、RemoteOK、golangprojects など）に、`provider: rss` と `rss:`（または `feed_url:`）キーを持つエントリを追加するだけでスキャナーを向けられます — **コード変更不要**。RSS アダプターは各 `<item>` を解析し（CDATA + HTML エンティティ、タイトル/会社名はタグ除去）、求人に正規化し、ATS ソースと同じ `title_filter` / `location_filter` + 重複排除 + パイプライン追記のフローを実行します。その後 **RSS** は `#/scan` のフィルタードロップダウンに選択可能なソースとして表示されます。(web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/ko-KR.md
+++ b/docs/help/ko-KR.md
@@ -593,6 +593,17 @@ Greenhouse / Ashby / Lever / Workable / SmartRecruiters / Workday
 가능한 ATS가 없는 회사는 건너뜁니다 (`/#/scan`의 **Active
 Companies** 카드에서 회색 `○`로 표시).
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+RSS/Atom 피드를 게시하는 모든 채용 보드(LaraJobs, WeWorkRemotely, RemoteOK, golangprojects 등)에 `provider: rss` 와 `rss:`(또는 `feed_url:`) 키를 가진 항목을 추가하기만 하면 스캐너를 연결할 수 있습니다 — **코드 변경 불필요**. RSS 어댑터는 각 `<item>` 을 파싱하고(CDATA + HTML 엔티티, 제목/회사명 태그 제거) 채용 공고로 정규화한 뒤, ATS 소스와 동일한 `title_filter` / `location_filter` + 중복 제거 + 파이프라인 추가 흐름을 실행합니다. 이후 **RSS** 가 `#/scan` 필터 드롭다운에 선택 가능한 소스로 표시됩니다. (web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/pt-BR.md
+++ b/docs/help/pt-BR.md
@@ -616,6 +616,17 @@ etc.) e busca a boards-api pública de cada empresa diretamente.
 Empresas sem um ATS reconhecível são puladas (o card **Active
 Companies** em `/#/scan` as mostra em cinza com `○`).
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+Aponte o scanner para qualquer portal de vagas que publique um feed RSS/Atom (LaraJobs, WeWorkRemotely, RemoteOK, golangprojects, …) adicionando uma entrada com `provider: rss` e uma chave `rss:` (ou `feed_url:`) — **sem mudanças de código**. O adaptador RSS analisa cada `<item>` (CDATA + entidades HTML, títulos/empresas sem tags), normaliza para uma vaga e executa o mesmo fluxo `title_filter` / `location_filter` + dedup + acréscimo ao pipeline das fontes ATS. Em seguida, **RSS** aparece como fonte selecionável no menu de filtro de `#/scan`. (web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/ru.md
+++ b/docs/help/ru.md
@@ -612,6 +612,17 @@ SmartRecruiters / Workday), `enabled: true|false` для
 Компании без распознаваемого ATS пропускаются (карточка **Active
 Companies** на `/#/scan` показывает их серыми с `○`).
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+Нацельте сканер на любой джоб-борд с RSS/Atom-фидом (LaraJobs, WeWorkRemotely, RemoteOK, golangprojects, …), добавив запись с `provider: rss` и ключом `rss:` (или `feed_url:`) — **без правок кода**. RSS-адаптер парсит каждый `<item>` (CDATA + HTML-сущности, заголовки/компании очищаются от тегов), нормализует в вакансию и прогоняет тот же `title_filter` / `location_filter` + дедуп + добавление в pipeline, что и ATS-источники. После этого **RSS** появляется как выбираемый источник в выпадающем фильтре на `#/scan`. (web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/zh-CN.md
+++ b/docs/help/zh-CN.md
@@ -549,6 +549,17 @@ Greenhouse 等)并直接调用每家公司的公共 boards-api。没有可识别
 的公司会被跳过(`/#/scan` 上的 **Active Companies** 卡片会用
 `○` 灰色显示)。
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+只需在 `portals.yml` 中添加一条带 `provider: rss` 与 `rss:`(或 `feed_url:`)键的条目,即可让扫描器对接任何发布 RSS/Atom 订阅源的招聘板(LaraJobs、WeWorkRemotely、RemoteOK、golangprojects 等)—— **无需改动代码**。RSS 适配器解析每个 `<item>`(CDATA + HTML 实体,标题/公司名去除标签),将其规范化为职位,并执行与 ATS 来源相同的 `title_filter` / `location_filter` + 去重 + 追加到 pipeline 的流程。随后 **RSS** 会作为可选来源出现在 `#/scan` 的筛选下拉框中。(web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/docs/help/zh-TW.md
+++ b/docs/help/zh-TW.md
@@ -552,6 +552,17 @@ Workday 端點)、`enabled: true|false` 可在不刪除條目的情況下
 公司公開的 boards-api。無法辨識 ATS 的公司會被略過(`/#/scan`
 上的 **Active Companies** 卡片會以灰色 `○` 顯示它們)。
 
+### `rss` (RSS / Atom boards)
+
+```yaml
+tracked_companies:
+  - { name: LaraJobs, enabled: true, provider: rss, rss: https://larajobs.com/feed }
+  - { name: WeWorkRemotely, enabled: true, provider: rss, rss: https://weworkremotely.com/remote-jobs.rss }
+```
+
+只需在 `portals.yml` 中加入一筆帶 `provider: rss` 與 `rss:`(或 `feed_url:`)鍵的項目,即可讓掃描器對接任何發佈 RSS/Atom 來源的徵才看板(LaraJobs、WeWorkRemotely、RemoteOK、golangprojects 等)—— **無需改動程式碼**。RSS 轉接器解析每個 `<item>`(CDATA + HTML 實體,標題/公司名去除標籤),將其正規化為職缺,並執行與 ATS 來源相同的 `title_filter` / `location_filter` + 去重 + 附加到 pipeline 的流程。隨後 **RSS** 會作為可選來源出現在 `#/scan` 的篩選下拉選單中。(web-ui v1.62.x)
+
+
 ### `russian_portals`
 
 ```yaml

--- a/tests/help-ru-config-section.test.mjs
+++ b/tests/help-ru-config-section.test.mjs
@@ -128,5 +128,5 @@ test('WS10: every help-bundle has identical H3 parity (en + 7 locales)', () => {
     if (baseline === null) baseline = h3;
     assert.equal(h3, baseline, `${lang}.md has ${h3} H3 subsections, expected ${baseline}`);
   }
-  assert.equal(baseline, 73, `expected 73 H3 subsections per bundle, got ${baseline}`); // v1.58.35 §18 added 3 H3s
+  assert.equal(baseline, 74, `expected 74 H3 subsections per bundle, got ${baseline}`); // v1.58.35 §18 added 3 H3s; v1.62.x §5 added "rss (RSS / Atom boards)"
 });


### PR DESCRIPTION
Adds a `### rss (RSS / Atom boards)` subsection under §5 (Portals & sources) in every `docs/help/<lang>.md` — covering `provider: rss` + `rss:`/`feed_url:`, the parsing/normalize/filter flow, and the RSS entry in the `#/scan` source filter. H3 parity 73 → 74 across all 9 locales; count bumped in `help-ru-config-section`. Docs-only; full suite 1032/1032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)