### PR TITLE
test(i18n): cover-mode + lang-select + RTL coverage; docs: finish 12-locale refresh

### DIFF
--- a/docs/sdd/CONVENTIONS.md
+++ b/docs/sdd/CONVENTIONS.md
@@ -80,7 +80,7 @@ Route reviewers (`web-ui-route-reviewer` agent) flag every miss.
 - `@alias` keys (sidebar label = page title = dashboard tile) share ONE translated string with their canonical key; alias targets must exist and must not themselves be aliases (`tools/i18n-audit.mjs` + `tests/i18n-alias.test.mjs` enforce it). Keys that merely collapse in English but diverge in another locale (e.g. `nav.config` vs `config.title`) are NOT aliased.
 - Help-bundle markdown lives in `docs/help/<locale>.md` (9 files: `en, es, pt-BR, ko-KR, ja, ru, zh-CN, zh-TW, fr`). The three v1.70.0 locales (pl/uk/ar) intentionally **fall back to `en.md`** via the help resolver — the long-form guide is not yet translated for them (the UI chrome is). CI invariant: **19 H2 sections** (`tests/canonical-docs-coverage.test.mjs` + `tests/help-ui.test.mjs` `SECTION_COUNT`). §19 "Localizing the app into your language" was added in v1.60.0.
 - `tests/i18n-coverage.test.mjs` enforces locale parity. If you add a key and forget a locale, that test fails.
-- CHANGELOG parity: all 8 `CHANGELOG*.md` files must reference the same `## [vX.Y.Z]` top — `scripts/check-changelog-parity.mjs` is the gate (part of `npm run test:ci`).
+- CHANGELOG parity: all 12 `CHANGELOG*.md` files (EN + 11 locales) must reference the same `## [vX.Y.Z]` top — `scripts/check-changelog-parity.mjs` is the gate (part of `npm run test:ci`).
 
 ## Error handling
 
@@ -104,7 +104,7 @@ Route reviewers (`web-ui-route-reviewer` agent) flag every miss.
 - Long-running tests (E2E): keep them under `tests/e2e*.mjs` / `tests/playwright-*.mjs`, not in the default `npm test` matcher. `npm run test:e2e:browser` drives them.
 - CI gates (run via `npm run test:ci`): unit + acceptance + `scripts/check-no-also-leftovers.mjs` (no `.also(` patterns leaking into views) + `scripts/check-changelog-parity.mjs` (all 11 non-EN locales at the same version).
 - Current count as of **v1.53.0**: **716** `node --test` cases across 90 files (unit + functional + acceptance) + 4 Playwright/E2E surfaces + the shell-surface tier (`tests/sh-files.test.mjs` — `bin/*.sh` + `.githooks` + `install-hooks` wiring, WS9). Run `npm run test:coverage` for the V8 report; see `docs/architecture/TESTING.md` for the 4-tier pyramid.
-- The CHANGELOG-parity gate enforces H2 across all 8 help bundles; `tests/help-ru-config-section.test.mjs` additionally locks **H3 parity** (73 per bundle) since WS10 (v1.54.0) — an en-only H3 addition can no longer silently diverge the localized bundles.
+- `tests/canonical-docs-coverage.test.mjs` enforces H2 across all 9 help bundles (pl/uk/ar fall back to `en.md`, so the help set stays 9); `tests/help-ru-config-section.test.mjs` additionally locks **H3 parity** (75 per bundle as of v1.69.0) — an en-only H3 addition can no longer silently diverge the localized bundles.
 
 ## LLM provider selection (v1.39.0, WS8.2)
 
@@ -179,7 +179,7 @@ conventions — match them in new views:
   `aria-sort`. Mouse-only handlers get `role`+`tabindex`+keydown.
 - **Long async relabels** (button text changing under the user) are
   announced via a polite `role=status` region.
-- Every user-facing string is i18n-keyed across all 8 locales (the
+- Every user-facing string is i18n-keyed across all 12 locales (the
   `i18n-coverage` gate enforces it); icons on peer CTAs are consistent.
 
 ## Commits

--- a/tests/lang-switcher-rtl.test.mjs
+++ b/tests/lang-switcher-rtl.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * I18N-EXPAND (v1.70.0) — coverage for the two behaviour changes that
+ * shipped with the 12-locale expansion:
+ *
+ *   1. The flag `<select>` language switcher (renderLangSwitcher in app.js)
+ *      replaced the wrapping `.lang-btn` row.
+ *   2. Arabic RTL: i18n.js writes `<html dir>` (rtl for RTL_LANGS, ltr
+ *      otherwise) on setLang() and at boot.
+ *
+ * The i18n behaviour is exercised by running the REAL dictionary + i18n.js
+ * in a vm with a captured `document` mock. The switcher DOM-build is a
+ * client IIFE that depends on Router/API/UI globals, so (per the repo
+ * convention used by qa-report-fixes) its wiring is asserted against source.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createContext, runInContext } from 'node:vm';
+import { runDictInto } from './helpers/i18n-vm.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const read = (...p) => readFileSync(resolve(ROOT, ...p), 'utf8');
+
+/** Boot the real i18n module in a vm with a captured document + storage. */
+function bootI18n() {
+  const doc = { documentElement: { lang: 'en', dir: 'ltr' }, addEventListener() {} };
+  const store = {};
+  const ctx = createContext({
+    window: {},
+    document: doc,
+    localStorage: { getItem: (k) => (k in store ? store[k] : null), setItem: (k, v) => { store[k] = v; } },
+    navigator: { language: 'en' },
+  });
+  runDictInto(ctx);
+  runInContext(read('public', 'js', 'lib', 'i18n.js'), ctx);
+  return { I18n: ctx.window.I18n, doc };
+}
+
+test('i18n: getLangs() exposes all 12 locales, each with code/label/flag', () => {
+  const { I18n } = bootI18n();
+  const langs = [...I18n.getLangs()]; // spread → main-realm array (getLangs is vm-realm)
+  const codes = langs.map((l) => l.code);
+  assert.deepEqual(
+    codes.sort(),
+    ['ar', 'en', 'es', 'fr', 'ja', 'ko', 'pl', 'pt-BR', 'ru', 'uk', 'zh-CN', 'zh-TW'].sort(),
+    '12 locales must be registered',
+  );
+  for (const l of langs) {
+    assert.ok(l.label && l.label.length, `${l.code} must have a label`);
+    assert.ok(l.flag && /\p{Regional_Indicator}/u.test(l.flag), `${l.code} must have a flag emoji`);
+  }
+});
+
+test('i18n RTL: setLang("ar") sets <html dir="rtl">; LTR locales reset it', () => {
+  const { I18n, doc } = bootI18n();
+  I18n.setLang('ar');
+  assert.equal(I18n.getLang(), 'ar');
+  assert.equal(doc.documentElement.dir, 'rtl', 'Arabic must flip <html dir> to rtl');
+  I18n.setLang('en');
+  assert.equal(doc.documentElement.dir, 'ltr', 'English must restore ltr');
+  I18n.setLang('uk'); // a non-RTL new locale stays ltr
+  assert.equal(doc.documentElement.dir, 'ltr', 'Ukrainian is LTR');
+});
+
+test('i18n: top.langLabel resolves (the <select> accessible name) in every locale', () => {
+  const { I18n } = bootI18n();
+  for (const l of I18n.getLangs()) {
+    I18n.setLang(l.code);
+    const v = I18n.t('top.langLabel');
+    assert.ok(v && v !== 'top.langLabel', `top.langLabel must be translated in ${l.code}`);
+  }
+});
+
+test('switcher source: renderLangSwitcher builds a <select> wired to setLang + aria-label', () => {
+  const app = read('public', 'js', 'app.js');
+  assert.match(app, /createElement\('select'\)/, 'must build a <select>');
+  assert.match(app, /createElement\('option'\)/, 'must build <option>s');
+  assert.match(app, /id = 'lang-select'/, 'select must carry id="lang-select" (tests + screenshot script target it)');
+  assert.match(app, /setAttribute\('aria-label', I18n\.t\('top\.langLabel'/, 'select must have a localized aria-label');
+  assert.match(app, /addEventListener\('change', \(\) => I18n\.setLang\(/, 'change must drive I18n.setLang');
+  assert.doesNotMatch(app, /class = 'lang-btn'/, 'the old .lang-btn row must be gone');
+});

--- a/tests/modes-endpoints.test.mjs
+++ b/tests/modes-endpoints.test.mjs
@@ -31,7 +31,7 @@ before(async () => {
   writeFileSync(resolve(dir, 'data', 'pipeline.md'), '# pipeline\n');
   writeFileSync(resolve(dir, 'modes', 'oferta.md'), 'oferta\n');
   // 7 mode templates with distinctive marker strings
-  for (const slug of ['project', 'training', 'followup', 'batch', 'contacto', 'interview-prep', 'patterns']) {
+  for (const slug of ['project', 'training', 'followup', 'batch', 'contacto', 'interview-prep', 'patterns', 'cover']) {
     writeFileSync(resolve(dir, 'modes', `${slug}.md`), `# ${slug}\nMARKER-${slug.toUpperCase()}\nReads cv.md\n`);
   }
   process.env.CAREER_OPS_ROOT = dir;
@@ -60,7 +60,9 @@ async function postMode(slug, body = {}) {
   return { status: res.status, body: await res.json() };
 }
 
-const ALL_SLUGS = ['project', 'training', 'followup', 'batch', 'contacto', 'interview-prep', 'patterns'];
+// v1.70.0 — `cover` (cover-letter mode) ported from the parent; the
+// parametrized loop below asserts it is allowlisted and assembles like the rest.
+const ALL_SLUGS = ['project', 'training', 'followup', 'batch', 'contacto', 'interview-prep', 'patterns', 'cover'];
 
 for (const slug of ALL_SLUGS) {
   test(`POST /api/mode/${slug} returns prompt with mode template content`, async () => {


### PR DESCRIPTION
Post-merge hardening for **v1.70.0** — addresses the AI-review findings on PR #30. No behaviour change.

## Tests added
- **Cover-letter mode** — `tests/modes-endpoints.test.mjs` now includes `cover` in the fixture + parametrized slug loop, so the existing integration harness asserts it is in `MODE_ALLOWLIST` and assembles like the other generic modes (closes "no test for cover mode" BLOCKER).
- **`<select>` switcher + RTL** — new `tests/lang-switcher-rtl.test.mjs` (real vm): `getLangs()` exposes 12 locales each with a flag; `setLang('ar')` sets `<html dir="rtl">` and LTR locales reset it; `top.langLabel` resolves in every locale; `renderLangSwitcher` is wired to `setLang` + a localized `aria-label`.

## Docs
- `docs/sdd/CONVENTIONS.md` — fixed 3 stale "all 8" lines the v1.70.0 PR missed (→ 12 locales / 9 help bundles / 75 H3).

## Review false-positives (verified, no action needed)
The parity "BLOCKERs" (`top.langLabel`, `nav.cover`, `cover.*` allegedly missing from some locales) were **diff-truncation artifacts** — `grep -c` confirms all three keys are present in all 12 locale files, and `check-changelog-parity` already enumerates 11 non-EN locales.

## Evidence
`npm run test:ci` → **1091/1091** unit · changelog parity 11 · i18n-audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)