### PR TITLE
docs(readme): unofficial-UI / no-affiliation disclaimer (all 12 locales)

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | **العربية**
 
+_واجهة غير رسمية — لا علاقة لها بـ career-ops / santifer ولا تحظى بموافقتهما._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#الاختبارات)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#الاختبارات)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#الاختبارات)

--- a/README.es.md
+++ b/README.es.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | **Español** | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_UI no oficial — sin afiliación ni respaldo de career-ops / santifer._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#tests)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#tests)

--- a/README.fr.md
+++ b/README.fr.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | **Français** | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_Interface non officielle — sans affiliation ni approbation de career-ops / santifer._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#tests)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#tests)

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | **日本語** | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_非公式 UI — career-ops / santifer とは提携しておらず、承認も受けていません。_
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#tests)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#tests)

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | **한국어** | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_비공식 UI — career-ops / santifer와 제휴하거나 보증받지 않았습니다._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#tests)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#tests)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **English** | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_Unofficial UI — not affiliated with or endorsed by career-ops / santifer._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#tests)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#tests)

--- a/README.pl.md
+++ b/README.pl.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | **Polski** | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_Nieoficjalny interfejs — niepowiązany z career-ops / santifer ani przez nich nieautoryzowany._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#testy)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#testy)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#testy)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | **Português (Brasil)** | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_UI não oficial — sem afiliação ou endosso de career-ops / santifer._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#testes)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#testes)

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | **Русский** | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_Неофициальный интерфейс — не аффилирован с career-ops / santifer и не одобрен ими._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#тесты)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#тесты)

--- a/README.uk.md
+++ b/README.uk.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | **Українська** | [العربية](README.ar.md)
 
+_Неофіційний інтерфейс — не пов'язаний із career-ops / santifer і не схвалений ними._
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#тести)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#тести)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#тести)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | **简体中文** | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_非官方界面 — 与 career-ops / santifer 无关联，亦未获其认可。_
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#tests)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#tests)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -5,6 +5,8 @@
 
 [English](README.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [简体中文](README.zh-CN.md) | **繁體中文** | [Français](README.fr.md) | [Polski](README.pl.md) | [Українська](README.uk.md) | [العربية](README.ar.md)
 
+_非官方介面 — 與 career-ops / santifer 無關聯，亦未獲其認可。_
+
 [![tests](https://img.shields.io/badge/tests-1134%20passed-brightgreen)](#tests)
 [![e2e](https://img.shields.io/badge/e2e-23%2F23%20%2B%2020%2F20-brightgreen)](#tests)
 [![playwright](https://img.shields.io/badge/playwright-CI%20green-brightgreen)](#tests)


### PR DESCRIPTION
## What

Adds one italic line near the top of every locale README (between the language switcher and the badges):

> _Unofficial UI — not affiliated with or endorsed by career-ops / santifer._

Translated natively into all 12 locales (en, es, pt-BR, ko, ja, ru, zh-CN, zh-TW, fr, pl, uk, ar).

## Why

MIT licenses the **copyright** of the code, not the **trademark/name**. This line explicitly disclaims any "passing off as official" claim regarding career-ops / santifer.

## Scope

Docs-only. No code, no version bump, no CHANGELOG (not a release). Pure README addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)