### PR TITLE
fix(i18n/ux): footer hint reads "Enter — <verb>" in all 13 locales (drop ⌘K/Ctrl+K)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -120,7 +120,7 @@
       <div class="sidebar-footer">
         <div class="lang-switcher" id="lang-switcher"></div>
         <div class="version" id="footer-version">v…</div>
-        <div class="hint" data-i18n="top.langhint">CTRL+K — search</div>
+        <div class="hint" data-i18n="top.langhint">Enter — search</div>
       </div>
     </aside>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -212,28 +212,20 @@ I18n.onChange(() => {
 
   // global search
   const search = document.getElementById('global-search');
-  // v1.56.4 — UX-N2: surface the Cmd/Ctrl+K shortcut visibly so
-  // sighted users discover it. The keybinding itself is wired further
-  // down; the badge is aria-hidden (aria-label already covers AT).
+  // v1.56.4 — UX-N2: surface the submit shortcut visibly so sighted users
+  // discover it. The badge reads "Enter" (v1.78.1); it is aria-hidden
+  // (the input aria-label already conveys the action to AT).
   const kbdHint = document.querySelector('.kbd-shortcut');
-  // I-6 (v1.58.20) — footer hint must show ⌘K on Mac, Ctrl+K elsewhere
-  // (was the EN-only literal "CTRL+K — search" on every locale and
-  // every platform). Same detection used for the top-bar badge.
+  // The visible badge reads "Enter" on every platform (v1.78.1) — Enter is the
+  // action that submits the search (non-URL → #/scan pre-filled; URL →
+  // auto-pipeline). The Cmd/Ctrl+K focus keybinding is kept as a bonus (wired
+  // further down) but is no longer surfaced as the hint.
   const isMac = /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '');
   if (kbdHint) {
     kbdHint.textContent = isMac ? kbdHint.dataset.mac : kbdHint.dataset.other;
   }
-  function applyFooterHotkey() {
-    const hint = document.querySelector('.sidebar-footer .hint[data-i18n="top.langhint"]');
-    if (!hint) return;
-    const hotkey = isMac ? '⌘K' : 'Ctrl+K';
-    // After applyI18n() the text is e.g. '{hotkey} — поиск'. Swap the
-    // {hotkey} token with the platform-specific combo so the footer
-    // matches the OS the user is on and the localized verb stays.
-    hint.textContent = hint.textContent.replace(/\{hotkey\}/g, hotkey);
-  }
-  applyFooterHotkey();
-  I18n.onChange(applyFooterHotkey);
+  // The footer hint (top.langhint) now reads "Enter — <verb>" straight from
+  // i18n in every locale — no {hotkey} token to substitute anymore.
 
   // v1.58.34 — Notifications drawer. Builds on top of U-13's
   // UI.getToastHistory() + UI.onToast() (v1.58.33). The drawer slides

--- a/public/js/lib/locales/i18n-dict.ar.js
+++ b/public/js/lib/locales/i18n-dict.ar.js
@@ -182,7 +182,7 @@ window.__I18N_DICT_AR = {
   'top.doctor': "الفحص",
   'top.quickscan': "فتح المسح",
   'top.themeToggle': "تبديل المظهر",
-  'top.langhint': "{hotkey} — بحث",
+  'top.langhint': "Enter — بحث",
   'top.langLabel': "اللغة",
   'common.loading': "جارٍ التحميل…",
   'common.error': "خطأ",

--- a/public/js/lib/locales/i18n-dict.da.js
+++ b/public/js/lib/locales/i18n-dict.da.js
@@ -182,7 +182,7 @@ window.__I18N_DICT_DA = {
   'top.doctor': "Doctor",
   'top.quickscan': "Åbn Scanning",
   'top.themeToggle': "Skift tema",
-  'top.langhint': "{hotkey} — søg",
+  'top.langhint': "Enter — søg",
   'top.langLabel': "Sprog",
   'common.loading': "Indlæser…",
   'common.error': "Fejl",

--- a/public/js/lib/locales/i18n-dict.en.js
+++ b/public/js/lib/locales/i18n-dict.en.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_EN = {
   'top.doctor': "Doctor",
   'top.quickscan': "Open Scan",
   'top.themeToggle': "Toggle theme",
-  'top.langhint': "{hotkey} — search",
+  'top.langhint': "Enter — search",
   'top.langLabel': "Language",
   'common.loading': "Loading…",
   'common.error': "Error",

--- a/public/js/lib/locales/i18n-dict.es.js
+++ b/public/js/lib/locales/i18n-dict.es.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_ES = {
   'top.doctor': "Diagnóstico",
   'top.quickscan': "Abrir Scan",
   'top.themeToggle': "Cambiar tema",
-  'top.langhint': "{hotkey} — buscar",
+  'top.langhint': "Enter — buscar",
   'top.langLabel': "Idioma",
   'common.loading': "Cargando…",
   'common.error': "Error",

--- a/public/js/lib/locales/i18n-dict.fr.js
+++ b/public/js/lib/locales/i18n-dict.fr.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_FR = {
   'top.doctor': "Docteur", // Doctor
   'top.quickscan': "Ouvrir un scan", // Open Scan
   'top.themeToggle': "Changer de thème", // Toggle theme
-  'top.langhint': "{hotkey} — recherche", // {hotkey} — search
+  'top.langhint': "Enter — recherche", // Enter — search
   'top.langLabel': "Langue",
   'common.loading': "Chargement…", // Loading…
   'common.error': "Erreur", // Error

--- a/public/js/lib/locales/i18n-dict.ja.js
+++ b/public/js/lib/locales/i18n-dict.ja.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_JA = {
   'top.doctor': "診断",
   'top.quickscan': "Scan を開く",
   'top.themeToggle': "テーマを切り替え",
-  'top.langhint': "{hotkey} — 検索",
+  'top.langhint': "Enter — 検索",
   'top.langLabel': "言語",
   'common.loading': "読み込み中…",
   'common.error': "エラー",

--- a/public/js/lib/locales/i18n-dict.ko.js
+++ b/public/js/lib/locales/i18n-dict.ko.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_KO = {
   'top.doctor': "진단",
   'top.quickscan': "Scan 열기",
   'top.themeToggle': "테마 전환",
-  'top.langhint': "{hotkey} — 검색",
+  'top.langhint': "Enter — 검색",
   'top.langLabel': "언어",
   'common.loading': "로딩 중…",
   'common.error': "오류",

--- a/public/js/lib/locales/i18n-dict.pl.js
+++ b/public/js/lib/locales/i18n-dict.pl.js
@@ -182,7 +182,7 @@ window.__I18N_DICT_PL = {
   'top.doctor': "Doctor",
   'top.quickscan': "Otwórz Skanowanie",
   'top.themeToggle': "Przełącz motyw",
-  'top.langhint': "{hotkey} — wyszukaj",
+  'top.langhint': "Enter — wyszukaj",
   'top.langLabel': "Język",
   'common.loading': "Ładowanie…",
   'common.error': "Błąd",

--- a/public/js/lib/locales/i18n-dict.pt-BR.js
+++ b/public/js/lib/locales/i18n-dict.pt-BR.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_PT_BR = {
   'top.doctor': "Diagnóstico",
   'top.quickscan': "Abrir Scan",
   'top.themeToggle': "Alternar tema",
-  'top.langhint': "{hotkey} — buscar",
+  'top.langhint': "Enter — buscar",
   'top.langLabel': "Idioma",
   'common.loading': "Carregando…",
   'common.error': "Erro",

--- a/public/js/lib/locales/i18n-dict.ru.js
+++ b/public/js/lib/locales/i18n-dict.ru.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_RU = {
   'top.doctor': "Диагностика",
   'top.quickscan': "Открыть Scan",
   'top.themeToggle': "Сменить тему",
-  'top.langhint': "{hotkey} — поиск",
+  'top.langhint': "Enter — поиск",
   'top.langLabel': "Язык",
   'common.loading': "Загрузка…",
   'common.error': "Ошибка",

--- a/public/js/lib/locales/i18n-dict.uk.js
+++ b/public/js/lib/locales/i18n-dict.uk.js
@@ -182,7 +182,7 @@ window.__I18N_DICT_UK = {
   'top.doctor': "Doctor",
   'top.quickscan': "Відкрити сканування",
   'top.themeToggle': "Переключити тему",
-  'top.langhint': "{hotkey} — пошук",
+  'top.langhint': "Enter — пошук",
   'top.langLabel': "Мова",
   'common.loading': "Завантаження…",
   'common.error': "Помилка",

--- a/public/js/lib/locales/i18n-dict.zh-CN.js
+++ b/public/js/lib/locales/i18n-dict.zh-CN.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_ZH_CN = {
   'top.doctor': "诊断",
   'top.quickscan': "打开 Scan",
   'top.themeToggle': "切换主题",
-  'top.langhint': "{hotkey} — 搜索",
+  'top.langhint': "Enter — 搜索",
   'top.langLabel': "语言",
   'common.loading': "加载中…",
   'common.error': "错误",

--- a/public/js/lib/locales/i18n-dict.zh-TW.js
+++ b/public/js/lib/locales/i18n-dict.zh-TW.js
@@ -183,7 +183,7 @@ window.__I18N_DICT_ZH_TW = {
   'top.doctor': "診斷",
   'top.quickscan': "開啟 Scan",
   'top.themeToggle': "切換主題",
-  'top.langhint': "{hotkey} — 搜尋",
+  'top.langhint': "Enter — 搜尋",
   'top.langLabel': "語言",
   'common.loading': "載入中…",
   'common.error': "錯誤",

--- a/tests/fixtures/i18n-dict.snapshot.json
+++ b/tests/fixtures/i18n-dict.snapshot.json
@@ -2610,19 +2610,19 @@
     "ar": "تبديل المظهر"
   },
   "top.langhint": {
-    "en": "{hotkey} — search",
-    "es": "{hotkey} — buscar",
-    "pt-BR": "{hotkey} — buscar",
-    "ko": "{hotkey} — 검색",
-    "ja": "{hotkey} — 検索",
-    "ru": "{hotkey} — поиск",
-    "zh-CN": "{hotkey} — 搜索",
-    "zh-TW": "{hotkey} — 搜尋",
-    "fr": "{hotkey} — recherche",
-    "pl": "{hotkey} — wyszukaj",
-    "uk": "{hotkey} — пошук",
-    "da": "{hotkey} — søg",
-    "ar": "{hotkey} — بحث"
+    "en": "Enter — search",
+    "es": "Enter — buscar",
+    "pt-BR": "Enter — buscar",
+    "ko": "Enter — 검색",
+    "ja": "Enter — 検索",
+    "ru": "Enter — поиск",
+    "zh-CN": "Enter — 搜索",
+    "zh-TW": "Enter — 搜尋",
+    "fr": "Enter — recherche",
+    "pl": "Enter — wyszukaj",
+    "uk": "Enter — пошук",
+    "da": "Enter — søg",
+    "ar": "Enter — بحث"
   },
   "top.langLabel": {
     "en": "Language",

--- a/tests/qa-report-fixes.test.mjs
+++ b/tests/qa-report-fixes.test.mjs
@@ -1065,27 +1065,30 @@ test('U-1 (v1.58.21): #/cv has a proper page-header H1 + subtitle (no `.cv-bread
   assert.equal(h1Count, 1, `cv.js must declare exactly one <h1>, got ${h1Count}`);
 });
 
-test('I-6 (v1.58.20): footer hotkey uses {hotkey} placeholder + per-platform substitution', () => {
-  // v1.58.3 footer showed 'CTRL+K — search' literally on every platform
-  // and locale. The i18n value now embeds {hotkey} so app.js can swap
-  // it to ⌘K on Mac and Ctrl+K elsewhere; the localized verb stays.
+test('footer hint reads "Enter — <verb>" in every locale (no ⌘K/Ctrl+K)', () => {
+  // The footer hint historically showed the focus hotkey (⌘K/Ctrl+K). It now
+  // reads "Enter — <verb>" everywhere, mirroring the search badge (v1.78.1):
+  // Enter is the action that actually submits the search. The localized verb
+  // stays; only the hotkey token was dropped. No more {hotkey} substitution.
   const dict = legacyDictText();
-  assert.match(dict, /'top\.langhint':\s*\{\s*en:\s*'\{hotkey\} — search'/,
-    "top.langhint EN must use '{hotkey} — search'");
-  for (const lang of ['es', 'pt-BR', 'ko', 'ja', 'ru', 'zh-CN', 'zh-TW']) {
+  assert.match(dict, /'top\.langhint':\s*\{\s*en:\s*'Enter — search'/,
+    "top.langhint EN must use 'Enter — search'");
+  for (const lang of ['es', 'pt-BR', 'ko', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'da', 'ar']) {
     const quotedKey = /-/.test(lang) ? `'${lang}'` : lang;
-    assert.match(dict, new RegExp(`${quotedKey.replace(/[\.]/g, '\\.')}:\\s*'\\{hotkey\\} — [^']+'`),
-      `top.langhint ${lang} must use '{hotkey} — <verb>' shape`);
+    assert.match(dict, new RegExp(`${quotedKey.replace(/[\.]/g, '\\.')}:\\s*'Enter — [^']+'`),
+      `top.langhint ${lang} must use 'Enter — <verb>' shape`);
   }
-  // app.js must apply the platform-specific substitution.
+  // The {hotkey} token and its platform substitution are gone for good.
+  assert.doesNotMatch(dict, /'top\.langhint':[^}]*\{hotkey\}/,
+    'top.langhint must no longer carry the {hotkey} token');
   const app = read('public', 'js', 'app.js');
-  assert.match(app, /applyFooterHotkey/, 'app.js must define applyFooterHotkey()');
-  assert.match(app, /isMac\s*\?\s*'⌘K'\s*:\s*'Ctrl\+K'/,
-    'applyFooterHotkey must branch ⌘K vs Ctrl+K');
-  assert.match(app, /\.replace\(\/\\\{hotkey\\\}\/g,\s*hotkey\)/,
-    "applyFooterHotkey must substitute {hotkey} placeholder");
-  assert.match(app, /I18n\.onChange\(applyFooterHotkey\)/,
-    'applyFooterHotkey must re-run on every language change');
+  assert.doesNotMatch(app, /applyFooterHotkey/,
+    'applyFooterHotkey must be gone — the footer hint comes straight from i18n');
+  assert.doesNotMatch(app, /isMac\s*\?\s*'⌘K'\s*:\s*'Ctrl\+K'/,
+    'no ⌘K/Ctrl+K branch should remain for the footer hint');
+  // The Cmd/Ctrl+K focus keybinding itself is intentionally kept (a bonus).
+  assert.match(app, /\(\s*e\.ctrlKey\s*\|\|\s*e\.metaKey\s*\)\s*&&\s*e\.key === 'k'/,
+    'Cmd/Ctrl+K focus keybinding must remain');
 });
 
 test('I-4 (v1.58.19): RU followup strings contain no Latin `cadence`/`follow-up` leakage', () => {


### PR DESCRIPTION
The search badge already reads Enter (v1.78.1); the sidebar footer still rendered the ⌘K/Ctrl+K focus hotkey via the {hotkey} token. Now reads `Enter — <verb>` in all 13 locales; dead applyFooterHotkey() removed; Cmd/Ctrl+K focus keybinding kept. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)