### PR TITLE
fix(scan): harden buildEndpoint host-pinning + resolve CodeQL findings (PR #60 review)

### DIFF
--- a/server/lib/portals/adapters/hackernews.mjs
+++ b/server/lib/portals/adapters/hackernews.mjs
@@ -20,8 +20,11 @@ export const hackernewsAdapter = {
   matches(company) {
     return company.provider === 'hackernews';
   },
-  buildEndpoint(company) {
-    return company.hackernews || company.api || 'https://hn.algolia.com';
+  buildEndpoint() {
+    // Nominal, FIXED value — fetchHackerNews ignores it and always uses the
+    // Algolia SEARCH_URL internally. Returning a constant (never a user-supplied
+    // company.api / company.hackernews) keeps an arbitrary URL out of the slot.
+    return 'https://hn.algolia.com';
   },
   fetch: fetchHackerNews,
 };

--- a/server/lib/portals/adapters/justjoin.mjs
+++ b/server/lib/portals/adapters/justjoin.mjs
@@ -37,7 +37,11 @@ export const justjoinAdapter = {
     if (candidate) {
       try {
         const u = new URL(candidate);
-        if (u.protocol === 'https:' && JUSTJOIN_HOST_RE.test(u.hostname)) {
+        // Host-pin AND require an `/api/` path: a browser job-offers URL
+        // (justjoin.it/job-offers/…) passes the host check but is NOT the
+        // candidate-api endpoint — it must never become the fetch target.
+        if (u.protocol === 'https:' && JUSTJOIN_HOST_RE.test(u.hostname)
+            && u.pathname.startsWith('/api/')) {
           return candidate;
         }
       } catch {

--- a/server/lib/portals/adapters/nofluffjobs.mjs
+++ b/server/lib/portals/adapters/nofluffjobs.mjs
@@ -42,7 +42,17 @@ export const nofluffjobsAdapter = {
    * but a browser careers_url is not the POST API — ignore it for endpoint.
    */
   buildEndpoint(company) {
-    return company.nofluffjobs || API_URL;
+    // Defence-in-depth: host-pin an explicit `nofluffjobs:` override here too
+    // (the source-level assertNoFluffUrl is the hard SSRF guard, but an
+    // off-host override should never reach the fetch slot in the first place).
+    const override = company.nofluffjobs;
+    if (override) {
+      try {
+        const u = new URL(override);
+        if (u.protocol === 'https:' && NOFLUFF_HOST_RE.test(u.hostname)) return override;
+      } catch { /* fall through to API_URL */ }
+    }
+    return API_URL;
   },
 
   fetch: fetchNoFluffJobs,

--- a/tests/qa-report-fixes.test.mjs
+++ b/tests/qa-report-fixes.test.mjs
@@ -1075,7 +1075,9 @@ test('footer hint reads "Enter — <verb>" in every locale (no ⌘K/Ctrl+K)', ()
     "top.langhint EN must use 'Enter — search'");
   for (const lang of ['es', 'pt-BR', 'ko', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'da', 'ar']) {
     const quotedKey = /-/.test(lang) ? `'${lang}'` : lang;
-    assert.match(dict, new RegExp(`${quotedKey.replace(/[\.]/g, '\\.')}:\\s*'Enter — [^']+'`),
+    // Escape EVERY regex metacharacter (incl. backslash) before interpolating.
+    const escKey = quotedKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.match(dict, new RegExp(`${escKey}:\\s*'Enter — [^']+'`),
       `top.langhint ${lang} must use 'Enter — <verb>' shape`);
   }
   // The {hotkey} token and its platform substitution are gone for good.

--- a/tests/sources-hackernews.test.mjs
+++ b/tests/sources-hackernews.test.mjs
@@ -239,9 +239,12 @@ test('adapter: matches only on provider=hackernews', () => {
   assert.equal(hackernewsAdapter.matches({}), false);
 });
 
-test('adapter: buildEndpoint returns a non-null string', () => {
+test('adapter: buildEndpoint returns a fixed hn.algolia.com string, ignoring overrides', () => {
   const ep = hackernewsAdapter.buildEndpoint({ provider: 'hackernews' });
-  assert.ok(typeof ep === 'string' && ep.length > 0);
+  assert.equal(ep, 'https://hn.algolia.com');
+  // A user-supplied override must NOT leak into the endpoint slot.
+  assert.equal(hackernewsAdapter.buildEndpoint({ hackernews: 'https://evil.com' }), 'https://hn.algolia.com');
+  assert.equal(hackernewsAdapter.buildEndpoint({ api: 'https://evil.com' }), 'https://hn.algolia.com');
 });
 
 test('adapter: id and label are correct', () => {

--- a/tests/sources-jobicy.test.mjs
+++ b/tests/sources-jobicy.test.mjs
@@ -126,7 +126,7 @@ test('fetchJobicy: drops rows with empty title', async () => {
 test('fetchJobicy: drops rows with bad host in URL', async () => {
   const fetchImpl = async () => ({ ok: true, json: async () => FAKE_RESPONSE });
   const jobs = await fetchJobicy(FEED_URL, { fetchImpl });
-  assert.ok(jobs.every((j) => j.url.includes('jobicy.com')));
+  assert.ok(jobs.every((j) => new URL(j.url).hostname === 'jobicy.com'));
 });
 
 test('fetchJobicy: throws on non-ok HTTP response', async () => {

--- a/tests/sources-justjoin.test.mjs
+++ b/tests/sources-justjoin.test.mjs
@@ -198,6 +198,13 @@ test('adapter.buildEndpoint: returns custom api if host is justjoin.it', () => {
   assert.equal(justjoinAdapter.buildEndpoint({ api: custom }), custom);
 });
 
+test('adapter.buildEndpoint: browser api/careers URL falls back to API_URL (never a fetch endpoint)', () => {
+  // A justjoin.it browser job-offers URL passes the host check but is NOT the
+  // candidate-api endpoint — it must fall back so fetchJustJoin gets JSON.
+  assert.equal(justjoinAdapter.buildEndpoint({ api: 'https://justjoin.it/job-offers/my-company' }), API_URL);
+  assert.equal(justjoinAdapter.buildEndpoint({ careers_url: 'https://justjoin.it/job-offers/x' }), API_URL);
+});
+
 test('adapter: id and label', () => {
   assert.equal(justjoinAdapter.id, 'justjoin');
   assert.equal(justjoinAdapter.label, 'JustJoin.it');

--- a/tests/sources-nofluffjobs.test.mjs
+++ b/tests/sources-nofluffjobs.test.mjs
@@ -9,7 +9,6 @@ import {
   assertNoFluffUrl,
   API_URL,
   JOB_BASE,
-  NOFLUFF_HOST_RE,
   meta,
 } from '../server/lib/sources/nofluffjobs.mjs';
 import { nofluffjobsAdapter } from '../server/lib/portals/adapters/nofluffjobs.mjs';
@@ -218,6 +217,12 @@ test('adapter.buildEndpoint: returns API_URL by default', () => {
 test('adapter.buildEndpoint: respects explicit nofluffjobs override key', () => {
   const override = 'https://nofluffjobs.com/api/search/posting?region=de';
   assert.equal(nofluffjobsAdapter.buildEndpoint({ nofluffjobs: override }), override);
+});
+
+test('adapter.buildEndpoint: off-host / non-https override falls back to API_URL', () => {
+  assert.equal(nofluffjobsAdapter.buildEndpoint({ nofluffjobs: 'https://evil.com/api/search/posting' }), API_URL);
+  assert.equal(nofluffjobsAdapter.buildEndpoint({ nofluffjobs: 'http://nofluffjobs.com/api/search/posting' }), API_URL);
+  assert.equal(nofluffjobsAdapter.buildEndpoint({ nofluffjobs: 'not a url' }), API_URL);
 });
 
 test('adapter.id and label', () => {

--- a/tests/sources-rippling.test.mjs
+++ b/tests/sources-rippling.test.mjs
@@ -98,7 +98,7 @@ test('fetchRippling: returns 12-field shape, source=rippling', async () => {
   const jobs = await fetchRippling(VALID_API_URL, { fetchImpl });
   // 2 valid (no-url and no-name dropped)
   assert.equal(jobs.length, 2);
-  const [j0, j1] = jobs;
+  const [j0] = jobs;
 
   // 12 fields present
   const REQUIRED = ['id','title','url','company','location','isRemote','workplaceType','salary','date','snippet','relocates','source'];


### PR DESCRIPTION
Follow-up to v1.81.0 — addresses AI-review + CodeQL findings: justjoin /api/ path-pin, nofluffjobs override host-pin, hackernews fixed endpoint, regex-escape + URL().hostname + unused-var CodeQL fixes, +3 regression tests. 1515 green; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)