### PR TITLE
fix(scan): drop un-keyable justjoin rows + canonicalize workplaceType enum (review polish)

### DIFF
--- a/server/lib/sources/4dayweek.mjs
+++ b/server/lib/sources/4dayweek.mjs
@@ -91,7 +91,7 @@ function normalize(j) {
   const locBase = [city, country].filter(Boolean).join(', ');
   const isRemote = j.remote === true || j.work_arrangement === 'remote' || first.work_arrangement === 'remote';
   const location = [locBase, isRemote ? 'Remote' : ''].filter(Boolean).join(', ');
-  const workplaceType = isRemote ? 'Remote' : locBase || '';
+  const workplaceType = isRemote ? 'Remote' : 'Onsite';
 
   // date: posted is epoch SECONDS → multiply by 1000 → YYYY-MM-DD
   let date = '';

--- a/server/lib/sources/justjoin.mjs
+++ b/server/lib/sources/justjoin.mjs
@@ -67,7 +67,8 @@ export async function fetchJustJoin(apiUrl = API_URL, opts = {}) {
   }
   return json
     .filter((o) => o && typeof o === 'object')
-    .map((o) => normalize(o));
+    .map((o) => normalize(o))
+    .filter(Boolean);
 }
 
 function workplaceType(o) {
@@ -103,13 +104,17 @@ function formatDate(value) {
 
 function normalize(o) {
   const slug = String(o.slug || o.id || '').trim();
+  // No stable key → drop the row (every other source does the same). A random
+  // id would mint a NEW id for the same posting on each scan, so scan-history
+  // dedup never recognizes it (and the url would be empty too).
+  if (!slug) return null;
   const wt = workplaceType(o);
   const city = String(o.city || '').trim();
   return {
-    id: `justjoin-${slug || Math.random().toString(36).slice(2)}`,
+    id: `justjoin-${slug}`,
     title: String(o.title || '').trim(),
     company: String(o.company_name || o.companyName || '').trim(),
-    url: slug ? `${JOB_BASE}${slug}` : '',
+    url: `${JOB_BASE}${slug}`,
     salary: formatSalary(o),
     location: city || wt,
     isRemote: wt === 'Remote',

--- a/server/lib/sources/landingjobs.mjs
+++ b/server/lib/sources/landingjobs.mjs
@@ -136,7 +136,7 @@ function normalize(j) {
     salary,
     location,
     isRemote,
-    workplaceType: isRemote ? 'Remote' : 'On-site',
+    workplaceType: isRemote ? 'Remote' : 'Onsite',
     relocates: false,
     date: toDateStr(j.published_at) || toDateStr(j.created_at),
     snippet: '',

--- a/server/lib/sources/nofluffjobs.mjs
+++ b/server/lib/sources/nofluffjobs.mjs
@@ -70,7 +70,7 @@ function normalize(p) {
   const location = [...new Set(locationParts.filter(Boolean))].join(', ');
 
   const isRemote = !!(p.fullyRemote || p.location?.fullyRemote);
-  const workplaceType = isRemote ? 'Remote' : (location ? 'Office' : '');
+  const workplaceType = isRemote ? 'Remote' : 'Onsite';
 
   // Salary: format range + currency if present
   let salary = '';

--- a/server/lib/sources/themuse.mjs
+++ b/server/lib/sources/themuse.mjs
@@ -72,11 +72,9 @@ function normalize(j) {
 
   const lowerLoc = location.toLowerCase();
   const isRemote = lowerLoc.includes('remote') || lowerLoc.includes('flexible');
-  const workplaceType = lowerLoc.includes('remote')
-    ? 'Remote'
-    : lowerLoc.includes('flexible')
-      ? 'Flexible'
-      : 'On-site';
+  // Canonical enum only (Remote / Hybrid / Onsite). "Flexible" → Remote so
+  // isRemote and workplaceType never disagree.
+  const workplaceType = isRemote ? 'Remote' : 'Onsite';
 
   const date =
     typeof j.publication_date === 'string'

--- a/tests/sources-justjoin.test.mjs
+++ b/tests/sources-justjoin.test.mjs
@@ -83,6 +83,20 @@ test('fetchJustJoin: id prefixed with "justjoin-"', async () => {
   assert.ok(jobs[1].id.startsWith('justjoin-'));
 });
 
+test('fetchJustJoin: offers with no slug/id are dropped (stable dedup, never a random id)', async () => {
+  // Previously a missing slug/id minted a random id + empty url, so the same
+  // posting got a new id every scan and dedup never matched. Such rows are
+  // now dropped, like every other source.
+  const fetchImpl = async () => ({ ok: true, json: async () => [
+    { slug: 'real-role', title: 'Real', company_name: 'Acme' },
+    { title: 'No Key', company_name: 'Ghost' }, // no slug AND no id → dropped
+  ] });
+  const jobs = await fetchJustJoin(API_URL, { fetchImpl });
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].id, 'justjoin-real-role');
+  assert.ok(jobs.every((j) => j.url && /^https:\/\/justjoin\.it\/job-offer\//.test(j.url)));
+});
+
 test('fetchJustJoin: workplace type mapping', async () => {
   const jobs = await fetchJustJoin(API_URL, { fetchImpl: fakeFetch });
   assert.equal(jobs[0].workplaceType, 'Hybrid');

--- a/tests/sources-justjoin.test.mjs
+++ b/tests/sources-justjoin.test.mjs
@@ -89,11 +89,13 @@ test('fetchJustJoin: offers with no slug/id are dropped (stable dedup, never a r
   // now dropped, like every other source.
   const fetchImpl = async () => ({ ok: true, json: async () => [
     { slug: 'real-role', title: 'Real', company_name: 'Acme' },
+    { id: 'abc123', title: 'Id Only', company_name: 'Initech' }, // id falls back as the key → kept
     { title: 'No Key', company_name: 'Ghost' }, // no slug AND no id → dropped
   ] });
   const jobs = await fetchJustJoin(API_URL, { fetchImpl });
-  assert.equal(jobs.length, 1);
+  assert.equal(jobs.length, 2); // real-role + abc123 kept; keyless dropped
   assert.equal(jobs[0].id, 'justjoin-real-role');
+  assert.equal(jobs[1].id, 'justjoin-abc123'); // slug = o.slug || o.id
   assert.ok(jobs.every((j) => j.url && /^https:\/\/justjoin\.it\/job-offer\//.test(j.url)));
 });
 

--- a/tests/sources-landingjobs.test.mjs
+++ b/tests/sources-landingjobs.test.mjs
@@ -135,7 +135,7 @@ test('fetchLandingjobs: second job (on-site, no salary, fallback date from creat
   assert.equal(job.id, 'landingjobs-1002');
   assert.equal(job.company, 'Globex Solutions');
   assert.equal(job.isRemote, false);
-  assert.equal(job.workplaceType, 'On-site');
+  assert.equal(job.workplaceType, 'Onsite');
   assert.equal(job.salary, '');
   assert.equal(job.date, '2026-06-20');
   assert.equal(job.source, 'landingjobs');

--- a/tests/sources-themuse.test.mjs
+++ b/tests/sources-themuse.test.mjs
@@ -57,7 +57,7 @@ test('fetchTheMuse: maps all 12 fields from a standard job', async () => {
   assert.equal(j.salary, '');
   assert.equal(j.location, 'New York, NY');
   assert.equal(j.isRemote, false);
-  assert.equal(j.workplaceType, 'On-site');
+  assert.equal(j.workplaceType, 'Onsite');
   assert.equal(j.relocates, false);
   assert.equal(j.date, '2026-06-15');
   assert.equal(j.snippet, '');
@@ -82,12 +82,13 @@ test('fetchTheMuse: isRemote true when location contains "Remote"', async () => 
   assert.equal(results[0].workplaceType, 'Remote');
 });
 
-test('fetchTheMuse: isRemote true when location contains "Flexible" (pure, no "remote")', async () => {
-  // "Flexible" alone → workplaceType Flexible; "Flexible / Remote" hits "remote" first → Remote
+test('fetchTheMuse: "Flexible" location → isRemote true, canonical Remote workplaceType', async () => {
+  // "Flexible" counts as remote-friendly, so isRemote and workplaceType agree
+  // on the canonical enum (Remote / Hybrid / Onsite — never the raw "Flexible").
   const job = makeJob({ locations: [{ name: 'Flexible' }] });
   const results = await fetchTheMuse(FEED_BASE, { fetchImpl: fakeOnePage([job]) });
   assert.equal(results[0].isRemote, true);
-  assert.equal(results[0].workplaceType, 'Flexible');
+  assert.equal(results[0].workplaceType, 'Remote');
 });
 
 test('fetchTheMuse: multiple locations are joined with ", "', async () => {


### PR DESCRIPTION
Post-v1.82.0 code-review follow-up (no version bump):
- **justjoin**: keyless offers (no slug AND no id) used to mint `justjoin-<random>` + empty url → dedup never matched on re-scan. Now dropped (like every other source). id-only offers still kept (slug = `o.slug || o.id`). +2 regression assertions.
- **workplaceType** canonicalized to Remote/Hybrid/Onsite: 4dayweek (raw location), landingjobs/themuse (`On-site`), nofluffjobs (`Office`), themuse (`Flexible`→Remote).

Review verdict was ship-as-is (no HIGH/SSRF). 1524 green; parity unchanged at v1.82.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)