### PR TITLE
fix: resolve CI/CodeQL review findings (post-v1.84.0)

### DIFF
--- a/qa/QA-REGRESSION-PROMPT.md
+++ b/qa/QA-REGRESSION-PROMPT.md
@@ -2,7 +2,7 @@
 
 Single standalone hand-off for a QA tester (human or agent) to verify the **entire** career-ops-ui build end-to-end, in **all 13 languages**. Walking this top-to-bottom signs off the build without needing the rest of the `qa/` tree.
 
-- **Version under test:** `package.json` **1.82.0** · parent career-ops v1.15.0 parity.
+- **Version under test:** `package.json` **1.84.0** · parent career-ops v1.15.0 parity.
 - **Baseline:** **1541** `node --test` cases · Playwright (smoke + full-cycle + forms + **locale-sweep ×13** + theme-toggle) · 20 smoke E2E · 23 comprehensive E2E · CI matrix green on Node 18/20/22 + Playwright + CodeQL.
 - **Server:** `npm start` → `http://127.0.0.1:4317`.
 - **Sibling docs:** `qa/QA-REGRESSION-PROMPT-v1.76.0-FULL.md` (parent-parity gate driver) · `key/E2E-REGRESSION-EVERY-BUTTON-EVERY-LANGUAGE-v1.78.0.md` (exhaustive UI click-through) · `REGRESSION-FINAL.md` (invariant ledger).
@@ -150,10 +150,10 @@ Locales: `en, es, pt-BR, ko, ja, ru, zh-CN, zh-TW, fr, pl, uk, da, ar` (dict fil
 
 ## §7 — Docs / branding / release mechanics
 
-- **README ×13** + **CHANGELOG ×13** at **v1.83.0** (parity gate green); each language switcher lists all 13 incl. **Dansk**. README "Latest release" blurb describes the repost detector. All 13 `images/dashboard-<locale>.png` regenerated with the new branding.
+- **README ×13** + **CHANGELOG ×13** at **v1.84.0** (parity gate green); each language switcher lists all 13 incl. **Dansk**. README "Latest release" blurb describes the re-apply cooldown + compensation-in-pipeline.md upgrades. All 13 `images/dashboard-<locale>.png` regenerated with the new branding.
 - **Help ×13** carry the Country-filter bullet; H2/H3 counts unchanged (19/75).
 - **Branding:** new radar icon as favicon (`favicon.ico` + 16/32 + apple-touch-icon) and sidebar logo; app name **career-ops-ui** in title + logo. Parent `career-ops` references intentionally unchanged.
-- **Release:** `package.json` 1.83.0; footer reads `/api/health`; `parentVersion` = 1.15.0 (independent; semver only — the `# x-release-please-version` comment is stripped). Tag `v1.83.0` → `release.yml` → `publish-package.yml` (GitHub Packages). `images/` holds only README/help screenshots (icon masters live in `public/`).
+- **Release:** `package.json` 1.84.0; footer reads `/api/health`; `parentVersion` = 1.15.0 (independent; semver only — the `# x-release-please-version` comment is stripped). Tag `v1.84.0` → `release.yml` → `publish-package.yml` (GitHub Packages). `images/` holds only README/help screenshots (icon masters live in `public/`).
 
 ---
 

--- a/server/lib/parsers.mjs
+++ b/server/lib/parsers.mjs
@@ -143,8 +143,10 @@ function defaultUrlGate(s) {
  */
 function sanitizePipelineComp(v) {
   if (typeof v !== 'string') return '';
-  // Cap the raw content FIRST, then neutralize a formula-lead, so the quote is
-  // never the character that gets truncated away.
+  // Cap the raw content to 80 chars FIRST, then prepend the formula-neutralizing
+  // quote. This preserves the LAST content char of a max-length cell (slicing
+  // after quoting would have dropped it). The `'` adds at most one char, so the
+  // cell is ≤ 81 — pipeline.md cell width is not contractually bounded.
   let s = v.replace(/[\r\n\t|]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80);
   if (!s) return '';
   if (/^[=+\-@]/.test(s)) s = `'${s}`;

--- a/server/lib/parsers.mjs
+++ b/server/lib/parsers.mjs
@@ -143,10 +143,12 @@ function defaultUrlGate(s) {
  */
 function sanitizePipelineComp(v) {
   if (typeof v !== 'string') return '';
-  let s = v.replace(/[\r\n\t|]+/g, ' ').replace(/\s+/g, ' ').trim();
+  // Cap the raw content FIRST, then neutralize a formula-lead, so the quote is
+  // never the character that gets truncated away.
+  let s = v.replace(/[\r\n\t|]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80);
   if (!s) return '';
   if (/^[=+\-@]/.test(s)) s = `'${s}`;
-  return s.slice(0, 80);
+  return s;
 }
 
 /**

--- a/tests/detect-reposts.test.mjs
+++ b/tests/detect-reposts.test.mjs
@@ -48,7 +48,7 @@ test('detectReposts: genuine repost flagged; same-url & distinct-role & out-of-w
   assert.equal(sre[0].repostCount, 2, 'sre-1 + sre-2 (sre-1 dup collapses; sre-3 out of window)');
   const urls = sre[0].appearances.map((a) => a.url);
   assert.equal(new Set(urls).size, urls.length, 'no duplicate urls within a cluster');
-  assert.ok(!urls.includes('https://acme.com/jobs/sre-3'), 'outside-window url excluded');
+  assert.ok(urls.every((u) => u !== 'https://acme.com/jobs/sre-3'), 'outside-window url excluded');
   // distinct Engineering Manager role never clusters
   assert.equal(clusters.filter((c) => /Engineering Manager/.test(c.role)).length, 0);
 });

--- a/tests/parsers.test.mjs
+++ b/tests/parsers.test.mjs
@@ -160,6 +160,16 @@ test('addPipelineUrl: no comp → bare URL line (backward compatible)', () => {
   assert.match(after, /```\nhttps:\/\/x\.com\/1\n```/);
 });
 
+test('addPipelineUrl: comp capped to 80 content chars, formula-lead keeps its last char', () => {
+  const long = '=' + 'A'.repeat(85);                 // 86 raw chars, formula lead
+  const after = addPipelineUrl('', 'https://x.com/1', { comp: long });
+  const cell = after.match(/https:\/\/x\.com\/1 \| (.+)\n/)[1];
+  // raw content sliced to 80 ('=' + 79 'A'), THEN the neutralizing quote → 81
+  assert.equal(cell, "'=" + 'A'.repeat(79));
+  assert.equal(cell.length, 81);
+  assert.deepEqual(parsePipeline(after), ['https://x.com/1']);
+});
+
 test('removePipelineUrl: removes url', () => {
   const before = '```\nhttps://a.com/1\nhttps://b.com/2\n```';
   const after = removePipelineUrl(before, 'https://a.com/1');


### PR DESCRIPTION
CodeQL url-match shape (detect-reposts.test), sanitizePipelineComp slice order, QA-prompt stale version refs (1.82.0/v1.83.0 → 1.84.0). The 'Cooldown skipped:' scan-log line is intentionally English (server output, QA §1.8). No version bump; 1542 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)