### PR TITLE
fix(scan): pipeline comp cell hard-capped to ≤80 (post-v1.84.0 review)

### DIFF
--- a/qa/QA-REGRESSION-PROMPT.md
+++ b/qa/QA-REGRESSION-PROMPT.md
@@ -3,7 +3,7 @@
 Single standalone hand-off for a QA tester (human or agent) to verify the **entire** career-ops-ui build end-to-end, in **all 13 languages**. Walking this top-to-bottom signs off the build without needing the rest of the `qa/` tree.
 
 - **Version under test:** `package.json` **1.84.0** · parent career-ops v1.15.0 parity.
-- **Baseline:** **1541** `node --test` cases · Playwright (smoke + full-cycle + forms + **locale-sweep ×13** + theme-toggle) · 20 smoke E2E · 23 comprehensive E2E · CI matrix green on Node 18/20/22 + Playwright + CodeQL.
+- **Baseline:** **1543** `node --test` cases · Playwright (smoke + full-cycle + forms + **locale-sweep ×13** + theme-toggle) · 20 smoke E2E · 23 comprehensive E2E · CI matrix green on Node 18/20/22 + Playwright + CodeQL.
 - **Server:** `npm start` → `http://127.0.0.1:4317`.
 - **Sibling docs:** `qa/QA-REGRESSION-PROMPT-v1.76.0-FULL.md` (parent-parity gate driver) · `key/E2E-REGRESSION-EVERY-BUTTON-EVERY-LANGUAGE-v1.78.0.md` (exhaustive UI click-through) · `REGRESSION-FINAL.md` (invariant ledger).
 
@@ -12,7 +12,7 @@ Single standalone hand-off for a QA tester (human or agent) to verify the **enti
 ## §0 — Gates (all must be green before sign-off)
 
 ```bash
-npm test                                    # full suite (≥1541 cases)
+npm test                                    # full suite (≥1543 cases)
 npm run test:ci                             # unit + check-no-also + check-changelog-parity + i18n-audit
 node tools/i18n-audit.mjs                   # "no hard failures — dictionary is clean"
 node scripts/check-changelog-parity.mjs     # "all 12 locales at v1.84.0" (EN + 12 = 13 files)
@@ -159,6 +159,6 @@ Locales: `en, es, pt-BR, ko, ja, ru, zh-CN, zh-TW, fr, pl, uk, da, ar` (dict fil
 
 ## §8 — Exit criteria
 - Every (page × control × 13 languages) PASS or a logged FAIL→fix (one-fix-per-release; HIGH → MEDIUM → LOW).
-- `npm test` ≥ **1541** green; `npm run test:ci` green; coverage ≥ floor; Playwright (locale-sweep ×13) green; CI matrix green.
+- `npm test` ≥ **1543** green; `npm run test:ci` green; coverage ≥ floor; Playwright (locale-sweep ×13) green; CI matrix green.
 - Zero console errors; no RTL leak; no untranslated shipped key; favicon/icon endpoints 200.
 - All §2 deltas verified live.

--- a/server/lib/parsers.mjs
+++ b/server/lib/parsers.mjs
@@ -143,14 +143,13 @@ function defaultUrlGate(s) {
  */
 function sanitizePipelineComp(v) {
   if (typeof v !== 'string') return '';
-  // Cap the raw content to 80 chars FIRST, then prepend the formula-neutralizing
-  // quote. This preserves the LAST content char of a max-length cell (slicing
-  // after quoting would have dropped it). The `'` adds at most one char, so the
-  // cell is ≤ 81 — pipeline.md cell width is not contractually bounded.
-  let s = v.replace(/[\r\n\t|]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80);
+  // Collapse injection chars (newline / tab / pipe), then hard-cap the cell to
+  // 80 chars TOTAL. For a formula-lead (= + - @) reserve one char for the
+  // neutralizing quote so the quoted cell still fits in 80 (never 81).
+  const s = v.replace(/[\r\n\t|]+/g, ' ').replace(/\s+/g, ' ').trim();
   if (!s) return '';
-  if (/^[=+\-@]/.test(s)) s = `'${s}`;
-  return s;
+  if (/^[=+\-@]/.test(s)) return `'${s.slice(0, 79)}`;
+  return s.slice(0, 80);
 }
 
 /**

--- a/tests/parsers.test.mjs
+++ b/tests/parsers.test.mjs
@@ -160,14 +160,18 @@ test('addPipelineUrl: no comp → bare URL line (backward compatible)', () => {
   assert.match(after, /```\nhttps:\/\/x\.com\/1\n```/);
 });
 
-test('addPipelineUrl: comp capped to 80 content chars, formula-lead keeps its last char', () => {
-  const long = '=' + 'A'.repeat(85);                 // 86 raw chars, formula lead
-  const after = addPipelineUrl('', 'https://x.com/1', { comp: long });
+test('addPipelineUrl: comp is hard-capped to 80 chars TOTAL (formula-lead reserves the quote)', () => {
+  // (a) formula-lead, over length → quote + 79 content chars = 80 total (not 81)
+  const after = addPipelineUrl('', 'https://x.com/1', { comp: '=' + 'A'.repeat(85) });
   const cell = after.match(/https:\/\/x\.com\/1 \| (.+)\n/)[1];
-  // raw content sliced to 80 ('=' + 79 'A'), THEN the neutralizing quote → 81
-  assert.equal(cell, "'=" + 'A'.repeat(79));
-  assert.equal(cell.length, 81);
+  assert.equal(cell, "'=" + 'A'.repeat(78));
+  assert.equal(cell.length, 80);
   assert.deepEqual(parsePipeline(after), ['https://x.com/1']);
+  // (b) non-formula, over length → exactly 80
+  const after2 = addPipelineUrl('', 'https://y.com/2', { comp: 'B'.repeat(90) });
+  const cell2 = after2.match(/https:\/\/y\.com\/2 \| (.+)\n/)[1];
+  assert.equal(cell2.length, 80);
+  assert.ok(!cell2.startsWith("'"));
 });
 
 test('removePipelineUrl: removes url', () => {


### PR DESCRIPTION
Resolves the AI-review finding: formula-lead comp cell was 81 chars (broke the ≤80 cap). Now reserves the quote char → always ≤80. +test. QA prompt full pass (count → 1543). No version bump; 1543 green.