### PR TITLE
test(help): extend help-ui locale coverage to all 16

### DIFF
--- a/tests/help-ui.test.mjs
+++ b/tests/help-ui.test.mjs
@@ -50,7 +50,7 @@ test('public/index.html includes the Help sidebar entry + help.js script tag', (
 
 // ─────────────── i18n coverage ───────────────
 
-const REQUIRED_LANGS = ['en', 'es', 'pt-BR', 'ko', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'ar'];
+const REQUIRED_LANGS = ['en', 'es', 'pt-BR', 'ko', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'da', 'ar', 'de', 'it', 'tr'];
 const REQUIRED_KEYS = ['nav.help', 'help.title', 'help.subtitle', 'help.toc'];
 
 test('i18n: nav.help / help.* keys present in every supported locale', () => {
@@ -76,13 +76,13 @@ test('i18n: nav.help / help.* keys present in every supported locale', () => {
 test('docs/help/{lang}.md exists for every supported locale', () => {
   const helpDir = resolve(ROOT, 'docs', 'help');
   // We accept either ko-KR.md or ko.md to mirror i18n's two naming conventions.
-  for (const lang of ['en', 'es', 'pt-BR', 'ko-KR', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'ar']) {
+  for (const lang of ['en', 'es', 'pt-BR', 'ko-KR', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'da', 'ar', 'de', 'it', 'tr']) {
     assert.ok(existsSync(resolve(helpDir, `${lang}.md`)),
       `docs/help/${lang}.md missing`);
   }
 });
 
-test('every help doc covers the same 20 sections (all gated locales — P-8 expanded, §20 v1.86.0)', () => {
+test('every help doc covers the same 28 sections (all 16 gated locales — §28 v1.96.0)', () => {
   // Full user-journey coverage: from initial setup + API keys to
   // applying for jobs and preparing for interviews. v1.9.2 expanded
   // from 14 → 16 sections (added App settings & API keys, Interview
@@ -92,7 +92,7 @@ test('every help doc covers the same 20 sections (all gated locales — P-8 expa
   // v1.60.0 — 18 → 19 (added §19 "Localizing the app into your language").
   const helpDir = resolve(ROOT, 'docs', 'help');
   const SECTION_COUNT = 28;
-  const ALL_LOCALES = ['en', 'es', 'pt-BR', 'ko-KR', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'ar'];
+  const ALL_LOCALES = ['en', 'es', 'pt-BR', 'ko-KR', 'ja', 'ru', 'zh-CN', 'zh-TW', 'fr', 'pl', 'uk', 'da', 'ar', 'de', 'it', 'tr'];
   for (const lang of ALL_LOCALES) {
     const fname = `${lang}.md`;
     const text = readFileSync(resolve(helpDir, fname), 'utf8');
@@ -110,7 +110,7 @@ test('every help locale has substantive content (P-8 floor)', () => {
   const helpDir = resolve(ROOT, 'docs', 'help');
   const en = readFileSync(resolve(helpDir, 'en.md'), 'utf8');
   const FLOOR = en.length * 0.3;
-  const ALL_LOCALES = ['es', 'pt-BR', 'ko-KR', 'ja', 'ru', 'zh-CN', 'zh-TW', 'pl', 'uk', 'ar'];
+  const ALL_LOCALES = ['es', 'pt-BR', 'ko-KR', 'ja', 'ru', 'zh-CN', 'zh-TW', 'pl', 'uk', 'da', 'ar', 'de', 'it', 'tr'];
   for (const lang of ALL_LOCALES) {
     const text = readFileSync(resolve(helpDir, `${lang}.md`), 'utf8');
     assert.ok(text.length >= FLOOR,


### PR DESCRIPTION
Closes a still-valid AI-review finding: `help-ui.test.mjs` locale arrays listed only 12 locales (da/de/it/tr unchecked). Extended to all 16 + refreshed a stale test title. Test-only, no runtime change. Suite 1661 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)