### PR TITLE
ci: tolerate publish E409 race + harden docs-assistant traversal test (PR #94 review follow-up)

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -75,7 +75,18 @@ jobs:
             exit 0
           fi
           echo "Publishing ${name}@${ver} …"
-          npm publish
+          # Tolerate a lost publish RACE: the release-triggered run and a manual
+          # workflow_dispatch for the same tag start together, both see "not yet
+          # published" above, and both call `npm publish` — the loser gets
+          # E409/EPUBLISHCONFLICT. That's success (the version IS on the
+          # registry), not a failure, so don't red-alarm the run.
+          out=$(npm publish 2>&1) && { echo "$out"; exit 0; }
+          echo "$out"
+          if echo "$out" | grep -qiE 'EPUBLISHCONFLICT|cannot publish over|409|already exists|previously published'; then
+            echo "::notice::${name}@${ver} was published by a concurrent run (E409) — treating as success."
+            exit 0
+          fi
+          exit 1
 
       - name: Reconcile `latest` dist-tag (semver-guarded)
         # A backfill or parallel publish — or an E409 idempotent skip on

--- a/tests/docs-assistant-routes.test.mjs
+++ b/tests/docs-assistant-routes.test.mjs
@@ -27,7 +27,12 @@ const post = (p, b) => fetch(`${baseUrl}${p}`, { method: 'POST', headers: { 'con
 test('resolveHelpFile falls back to en.md and is path-traversal safe', () => {
   assert.ok(resolveHelpFile('en'));
   assert.ok(resolveHelpFile('zz-unknown'));                 // → en.md fallback
-  assert.match(resolveHelpFile('../../etc/passwd') || 'en.md', /help/); // sanitized, never escapes
+  // A traversal attempt must resolve to a real file INSIDE docs/help (never
+  // /etc/passwd). Assert the actual return (no `|| fallback` masking a null).
+  const traversed = resolveHelpFile('../../etc/passwd');
+  assert.ok(traversed, 'traversal input must still resolve (to the en.md fallback), not null');
+  assert.match(traversed, /docs[/\\]help[/\\][a-zA-Z0-9_-]+\.md$/); // stayed inside docs/help
+  assert.doesNotMatch(traversed, /etc[/\\]passwd/);                 // never escaped
 });
 
 test('splitSections splits on ## and keeps ### inside their parent', () => {


### PR DESCRIPTION
Two small follow-ups from the PR #94 AI review and the publish false-alarm the maintainer flagged. **CI + test only — no version bump, no runtime change.**

1. **`publish-package.yml` — tolerate the publish race.** When `gh release create` fires the release-triggered publish AND a manual `workflow_dispatch` runs for the same tag, both start together, both pass the `npm view` idempotent check ("not yet published"), and both call `npm publish`. The loser gets `E409/EPUBLISHCONFLICT` and reddens the run — even though the version **is** on the registry. That's exactly what happened for v1.101.0. The publish step now treats that conflict as success.

2. **`tests/docs-assistant-routes.test.mjs` — strengthen the traversal assertion.** It used `resolveHelpFile(...) || 'en.md'`, which masked a null return. It now asserts the actual return is non-null, resolves **inside** `docs/help`, and never resolves to `/etc/passwd`.

Full suite unaffected (6/6 docs-assistant cases pass); workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)