### PR TITLE
docs(qa): v1.118.2 QA prompts + README tests-table actualization ×16

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -143,7 +143,7 @@ career-ops/
 └─ web-ui/          ← هذا المستودع
    ├─ server/       # Express + 15 وحدة مسارات
    ├─ public/       # vanilla JS SPA — بدون bundler
-   └─ tests/        # 1086 unit + 70 Playwright + 43 e2e
+   └─ tests/        # 1822 unit + 90 Playwright + 43 e2e
 ```
 
 <div dir="rtl">
@@ -168,7 +168,7 @@ career-ops/
 </div>
 
 ```bash
-npm test                    # 1086 اختبار وحدة وتكامل
+npm test                    # 1822 اختبار وحدة وتكامل
 npm run test:e2e            # 20 اختبار e2e دخاني
 npm run test:e2e:full       # 23 اختبار e2e شامل
 npm run test:e2e:browser    # 70 اختبار Playwright

--- a/README.da.md
+++ b/README.da.md
@@ -400,7 +400,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.60.0)
+└─ tests/                    # 1822 unit + 90 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.118.2)
    ├─ parsers.test.mjs       # markdown / pipeline / report parsers (pure functions)
    ├─ api.test.mjs           # every endpoint, ephemeral server, no network
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -531,22 +531,22 @@ Når `run: true` er sat på `/api/deep` eller `/api/mode/:slug`, foretrækker se
 ## Tests
 
 ```bash
-npm test                       # 1000 unit/integration tests
+npm test                       # 1822 unit/integration tests
 npm run test:e2e               # 20 smoke e2e (boots own server)
 npm run test:e2e:full          # 23 comprehensive e2e
-npm run test:e2e:browser       # 70 Playwright browser (smoke + full-cycle + forms + locale-sweep)
+npm run test:e2e:browser       # 90 Playwright browser (smoke + full-cycle + forms + locale-sweep ×16 + theme)
 npm run test:coverage          # same as `npm test` plus V8 coverage
 ```
 
 | Suite                       | Tests | What                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integration) | **1000** | Every endpoint, ephemeral server, no network. 110 files: parsers, scanners (mocked), runners, anthropic/openai, security headers, XSS, JD sanitize, URL validation, i18n parity, + the v1.55→v1.56 UX-fix suites. |
+| `node --test tests/*.test.mjs` (unit + integration) | **1822** | Every endpoint, ephemeral server, no network. 215 files: parsers, scanners (mocked), runners, anthropic/openai, security headers, XSS, JD sanitize, URL validation, i18n parity, + the v1.55→v1.56 UX-fix suites. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless: every route renders, basic flows.                                                     |
 | `tests/e2e-comprehensive.mjs` | 23    | Full Playwright walkthrough: 11 routes + 12 functional flows.                                              |
-| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **70** | Browser-driven: dashboard render, navigation, language switch, 404, health, tracker round-trip, pipeline add + invalid-URL sweep, reports, evaluate manual fallback, config keys masked, CV PUT XSS strip, pipeline preview 400, auto-pipeline SSE. |
-| **Total**                   | **1113** | **0 fails, 0 flakes**                                                                                    |
+| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **90** | Browser-driven: dashboard render, navigation, language switch, 404, health, tracker round-trip, pipeline add + invalid-URL sweep, reports, evaluate manual fallback, config keys masked, CV PUT XSS strip, pipeline preview 400, auto-pipeline SSE. |
+| **Total**                   | **1955** | **0 fails, 0 flakes**                                                                                    |
 
-Dækning: ~95.7 % linjer / ~87 % grene via `--experimental-test-coverage`.
+Dækning: ~93 % linjer / ~83 % grene via `--experimental-test-coverage`.
 
 Parsere er rene funktioner (ingen I/O) — testet mod rigtige datafragmenter fra `applications.md`, `pipeline.md` og `reports/*.md`. API-tests booter Express-appen på en flygtig port og udøver hvert endpoint ende-til-ende. Scanner-tests mocker `fetch`, så de består, selv hvis hh.ru blokerer din IP. Playwright-browser-smoke kører mod in-process-serveren og løser Playwright via det overordnede projekts `node_modules` — ingen ny afhængighed i `web-ui/`.
 

--- a/README.de.md
+++ b/README.de.md
@@ -400,7 +400,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.60.0)
+└─ tests/                    # 1822 unit + 90 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.118.2)
    ├─ parsers.test.mjs       # markdown / pipeline / report parsers (pure functions)
    ├─ api.test.mjs           # every endpoint, ephemeral server, no network
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -531,22 +531,22 @@ Wenn `run: true` bei `/api/deep` oder `/api/mode/:slug` gesetzt ist, bevorzugt d
 ## Tests
 
 ```bash
-npm test                       # 1000 unit/integration tests
+npm test                       # 1822 unit/integration tests
 npm run test:e2e               # 20 smoke e2e (boots own server)
 npm run test:e2e:full          # 23 comprehensive e2e
-npm run test:e2e:browser       # 70 Playwright browser (smoke + full-cycle + forms + locale-sweep)
+npm run test:e2e:browser       # 90 Playwright browser (smoke + full-cycle + forms + locale-sweep ×16 + theme)
 npm run test:coverage          # same as `npm test` plus V8 coverage
 ```
 
 | Suite                       | Tests | Was                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integration) | **1000** | Jeder Endpunkt, ephemerer Server, kein Netzwerk. 110 Dateien: Parser, Scanner (gemockt), Runner, anthropic/openai, Security-Header, XSS, JD-Sanitize, URL-Validierung, i18n-Parität, + die UX-Fix-Suites v1.55→v1.56. |
+| `node --test tests/*.test.mjs` (unit + integration) | **1822** | Jeder Endpunkt, ephemerer Server, kein Netzwerk. 215 Dateien: Parser, Scanner (gemockt), Runner, anthropic/openai, Security-Header, XSS, JD-Sanitize, URL-Validierung, i18n-Parität, + die UX-Fix-Suites v1.55→v1.56. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless: jede Route rendert, grundlegende Flows.                                                     |
 | `tests/e2e-comprehensive.mjs` | 23    | Vollständiger Playwright-Durchlauf: 11 Routen + 12 funktionale Flows.                                              |
-| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **70** | Browsergesteuert: Dashboard-Rendering, Navigation, Sprachwechsel, 404, Health, Tracker-Round-Trip, Pipeline-Add + Invalid-URL-Sweep, Reports, Evaluate-Manual-Fallback, Config-Keys maskiert, CV-PUT-XSS-Strip, Pipeline-Preview 400, Auto-Pipeline-SSE. |
-| **Gesamt**                   | **1113** | **0 Fehler, 0 Flakes**                                                                                    |
+| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **90** | Browsergesteuert: Dashboard-Rendering, Navigation, Sprachwechsel, 404, Health, Tracker-Round-Trip, Pipeline-Add + Invalid-URL-Sweep, Reports, Evaluate-Manual-Fallback, Config-Keys maskiert, CV-PUT-XSS-Strip, Pipeline-Preview 400, Auto-Pipeline-SSE. |
+| **Gesamt**                   | **1955** | **0 Fehler, 0 Flakes**                                                                                    |
 
-Abdeckung: ~95,7 % Zeilen / ~87 % Zweige über `--experimental-test-coverage`.
+Abdeckung: ~93 % Zeilen / ~83 % Zweige über `--experimental-test-coverage`.
 
 Parser sind reine Funktionen (kein I/O) — getestet gegen echte Datenfragmente aus `applications.md`, `pipeline.md` und `reports/*.md`. Die API-Tests booten die Express-App auf einem ephemeren Port und üben jeden Endpunkt end-to-end. Scanner-Tests mocken `fetch`, sodass sie auch dann bestehen, wenn hh.ru Ihre IP blockiert. Der Playwright-Browser-Smoke läuft gegen den In-Process-Server und löst Playwright über die `node_modules` des übergeordneten Projekts auf — keine neue Abhängigkeit in `web-ui/`.
 

--- a/README.es.md
+++ b/README.es.md
@@ -370,7 +370,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23 e2e:full + 20 e2e:smoke
+└─ tests/                    # 1822 unit + 90 Playwright + 23 e2e:full + 20 e2e:smoke
    ├─ parsers.test.mjs       # parsers markdown / pipeline / report (funciones puras)
    ├─ api.test.mjs           # cada endpoint, servidor efímero, sin red
    ├─ {ru,en}-scanner.test.mjs   # fetch mockeado
@@ -504,7 +504,7 @@ Cuando se establece `run: true` en `/api/deep` o `/api/mode/:slug`, el servidor 
 ## Tests
 
 ```bash
-npm test                       # 1000 tests unit/integración
+npm test                       # 1822 tests unit/integración
 npm run test:e2e               # 20 smoke e2e (arranca su propio servidor)
 npm run test:e2e:full          # 23 e2e completos
 npm run test:e2e:browser       # 32 smoke Playwright en navegador
@@ -513,7 +513,7 @@ npm run test:coverage          # igual que `npm test` más cobertura V8
 
 | Suite                       | Tests | Qué cubre                                                                                                  |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integración) | **1000** | Cada endpoint, servidor efímero, sin red. Incluye parser, scanner (mockeado), runner, anthropic, security headers, XSS, JD sanitize, validación de URL, DNS rebind, mutex de archivo, rate limit, path traversal y paridad i18n. |
+| `node --test tests/*.test.mjs` (unit + integración) | **1822** | Cada endpoint, servidor efímero, sin red. Incluye parser, scanner (mockeado), runner, anthropic, security headers, XSS, JD sanitize, validación de URL, DNS rebind, mutex de archivo, rate limit, path traversal y paridad i18n. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless: cada ruta renderiza, flujos básicos.                                                  |
 | `tests/e2e-comprehensive.mjs` | 23   | Walkthrough Playwright completo: 11 rutas + 12 flujos funcionales.                                         |
 | `tests/playwright-smoke.mjs` (`npm run test:e2e:browser`) | **32** | Smoke con navegador: render del dashboard, navegación, cambio de idioma, 404, health, tracker round-trip (BF-1), añadir a pipeline + barrido de URL inválida, reports vacío, evaluate manual fallback, claves de config enmascaradas, CV PUT XSS strip, pipeline preview 400. |
@@ -613,7 +613,7 @@ La interfaz incluye **16 idiomas** — `en`, `es`, `pt-BR`, `ko`, `ja`, `ru`, `z
 
 Issues y PRs bienvenidos. Reglas de la casa:
 
-- Ejecuta `npm test` antes de hacer push — **1000 checks en verde** es el mínimo (más 70 Playwright si tocas la UI).
+- Ejecuta `npm test` antes de hacer push — **1822 checks en verde** es el mínimo (más 90 Playwright si tocas la UI).
 - Los cambios no triviales pasan por la pipeline GSD. Ver [`docs/sdd/SDD-GUIDE.md`](docs/sdd/SDD-GUIDE.md).
 - No modifiques nada del proyecto padre `career-ops/` desde dentro de este repositorio. Todo el sentido es que sea una capa no invasiva. Reglas duras en [`CLAUDE.md`](CLAUDE.md).
 - Conventional commits: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`. Scope opcional: `feat(scan):`. Breaking change: `feat!:`.

--- a/README.fr.md
+++ b/README.fr.md
@@ -366,7 +366,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1001 unit + 70 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.61.0)
+└─ tests/                    # 1822 unit + 90 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.118.2)
    ├─ parsers.test.mjs       # markdown / pipeline / report parsers (pure functions)
    ├─ api.test.mjs           # every endpoint, ephemeral server, no network
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -497,22 +497,22 @@ Quand `run: true` est défini sur `/api/deep` ou `/api/mode/:slug`, le serveur p
 ## Tests
 
 ```bash
-npm test                       # 1001 unit/integration tests
+npm test                       # 1822 unit/integration tests
 npm run test:e2e               # 20 smoke e2e (boots own server)
 npm run test:e2e:full          # 23 comprehensive e2e
-npm run test:e2e:browser       # 70 Playwright browser (smoke + full-cycle + forms + locale-sweep)
+npm run test:e2e:browser       # 90 Playwright browser (smoke + full-cycle + forms + locale-sweep ×16 + theme)
 npm run test:coverage          # same as `npm test` plus V8 coverage
 ```
 
 | Suite                       | Tests | Quoi                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + intégration) | **1001** | Chaque endpoint, serveur éphémère, sans réseau. 110 fichiers : parsers, scanners (mockés), runners, anthropic/openai, en-têtes de sécurité, XSS, désinfection d'offre, validation d'URL, parité i18n, + les suites de fixes UX v1.55→v1.56. |
+| `node --test tests/*.test.mjs` (unit + intégration) | **1822** | Chaque endpoint, serveur éphémère, sans réseau. 215 fichiers : parsers, scanners (mockés), runners, anthropic/openai, en-têtes de sécurité, XSS, désinfection d'offre, validation d'URL, parité i18n, + les suites de fixes UX v1.55→v1.56. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless : chaque route s'affiche, flux de base.                                                |
 | `tests/e2e-comprehensive.mjs` | 23    | Parcours Playwright complet : 11 routes + 12 flux fonctionnels.                                            |
-| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **70** | Piloté par navigateur : rendu du dashboard, navigation, changement de langue, 404, health, aller-retour tracker, ajout pipeline + balayage URL-invalide, rapports, repli manuel d'évaluation, clés de config masquées, retrait XSS au PUT du CV, aperçu pipeline 400, SSE auto-pipeline. |
-| **Total**                   | **1114** | **0 échec, 0 flake**                                                                                    |
+| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **90** | Piloté par navigateur : rendu du dashboard, navigation, changement de langue, 404, health, aller-retour tracker, ajout pipeline + balayage URL-invalide, rapports, repli manuel d'évaluation, clés de config masquées, retrait XSS au PUT du CV, aperçu pipeline 400, SSE auto-pipeline. |
+| **Total**                   | **1955** | **0 échec, 0 flake**                                                                                    |
 
-Couverture : ~95,7 % ligne / ~87 % branche via `--experimental-test-coverage`.
+Couverture : ~93 % ligne / ~83 % branche via `--experimental-test-coverage`.
 
 Les parsers sont des fonctions pures (sans I/O) — testées contre de vrais fragments de données de `applications.md`, `pipeline.md` et `reports/*.md`. Les tests d'API démarrent l'app Express sur un port éphémère et exercent chaque endpoint de bout en bout. Les tests de scanner mockent `fetch` pour passer même si hh.ru bloque votre IP. Le smoke navigateur Playwright tourne contre le serveur en-process et résout Playwright via le `node_modules` du projet parent — aucune nouvelle dépendance dans `web-ui/`.
 

--- a/README.it.md
+++ b/README.it.md
@@ -400,7 +400,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.60.0)
+└─ tests/                    # 1822 unit + 90 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.118.2)
    ├─ parsers.test.mjs       # markdown / pipeline / report parsers (pure functions)
    ├─ api.test.mjs           # every endpoint, ephemeral server, no network
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -531,22 +531,22 @@ Quando `run: true` è impostato su `/api/deep` o `/api/mode/:slug`, il server pr
 ## Test
 
 ```bash
-npm test                       # 1000 unit/integration tests
+npm test                       # 1822 unit/integration tests
 npm run test:e2e               # 20 smoke e2e (boots own server)
 npm run test:e2e:full          # 23 comprehensive e2e
-npm run test:e2e:browser       # 70 Playwright browser (smoke + full-cycle + forms + locale-sweep)
+npm run test:e2e:browser       # 90 Playwright browser (smoke + full-cycle + forms + locale-sweep ×16 + theme)
 npm run test:coverage          # same as `npm test` plus V8 coverage
 ```
 
 | Suite                       | Test | Cosa                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integration) | **1000** | Ogni endpoint, server effimero, nessuna rete. 110 file: parser, scanner (mockati), runner, anthropic/openai, header di sicurezza, XSS, sanitizzazione JD, validazione URL, parità i18n, + le suite di correzioni UX v1.55→v1.56. |
+| `node --test tests/*.test.mjs` (unit + integration) | **1822** | Ogni endpoint, server effimero, nessuna rete. 215 file: parser, scanner (mockati), runner, anthropic/openai, header di sicurezza, XSS, sanitizzazione JD, validazione URL, parità i18n, + le suite di correzioni UX v1.55→v1.56. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless: ogni rotta viene renderizzata, flussi di base.                                                     |
 | `tests/e2e-comprehensive.mjs` | 23    | Walkthrough Playwright completo: 11 rotte + 12 flussi funzionali.                                              |
-| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **70** | Guidati da browser: render della dashboard, navigazione, cambio lingua, 404, health, round-trip del tracker, aggiunta alla pipeline + sweep di URL non validi, report, fallback manuale di evaluate, chiavi di config mascherate, rimozione XSS su CV PUT, anteprima pipeline 400, SSE auto-pipeline. |
-| **Totale**                   | **1113** | **0 fallimenti, 0 flake**                                                                                    |
+| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **90** | Guidati da browser: render della dashboard, navigazione, cambio lingua, 404, health, round-trip del tracker, aggiunta alla pipeline + sweep di URL non validi, report, fallback manuale di evaluate, chiavi di config mascherate, rimozione XSS su CV PUT, anteprima pipeline 400, SSE auto-pipeline. |
+| **Totale**                   | **1955** | **0 fallimenti, 0 flake**                                                                                    |
 
-Copertura: ~95,7% righe / ~87% branch tramite `--experimental-test-coverage`.
+Copertura: ~93% righe / ~83% branch tramite `--experimental-test-coverage`.
 
 I parser sono funzioni pure (nessun I/O) — testati contro frammenti di dati reali da `applications.md`, `pipeline.md` e `reports/*.md`. I test API avviano l'app Express su una porta effimera ed esercitano ogni endpoint end-to-end. I test dello scanner mockano `fetch` così passano anche se hh.ru blocca il tuo IP. Lo smoke browser Playwright gira contro il server in-process e risolve Playwright tramite i `node_modules` del progetto principale — nessuna nuova dipendenza in `web-ui/`.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -372,7 +372,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + e2e:full + e2e:smoke
+└─ tests/                    # 1822 unit + 90 Playwright + e2e:full + e2e:smoke
    ├─ parsers.test.mjs       # markdown / pipeline / report パーサー(純粋関数)
    ├─ api.test.mjs           # 全エンドポイント、ephemeral server、ネットワークなし
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -508,7 +508,7 @@ LLM エンドポイントはレート制限の対象です(`server/lib/rate-limi
 ## テスト
 
 ```bash
-npm test                       # 1000 unit/integration テスト
+npm test                       # 1822 unit/integration テスト
 npm run test:e2e               # 20 smoke e2e(独自サーバーを起動)
 npm run test:e2e:full          # 23 comprehensive e2e
 npm run test:e2e:browser       # 70 Playwright browser-smoke
@@ -517,7 +517,7 @@ npm run test:coverage          # `npm test` 相当 + V8 coverage
 
 | スイート                       | テスト数 | 内容                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs`(unit + integration) | **1000** | 全エンドポイント、ephemeral server、ネットワーク非依存。parser、scanner(モック)、runner、anthropic、security headers、XSS、JD サニタイズ、URL バリデーション、i18n parity、レート制限、ファイルロック、safe-fetch、path-traversal、DNS リバインドリダイレクトを含みます。 |
+| `node --test tests/*.test.mjs`(unit + integration) | **1822** | 全エンドポイント、ephemeral server、ネットワーク非依存。parser、scanner(モック)、runner、anthropic、security headers、XSS、JD サニタイズ、URL バリデーション、i18n parity、レート制限、ファイルロック、safe-fetch、path-traversal、DNS リバインドリダイレクトを含みます。 |
 | `tests/e2e.mjs`(smoke)     | 20    | Playwright ヘッドレス: 各 route のレンダリングと基本フロー。                                                |
 | `tests/e2e-comprehensive.mjs` | 23    | Playwright による完全な walkthrough: 11 routes + 12 機能フロー。                                          |
 | `tests/playwright-smoke.mjs`(`npm run test:e2e:browser`) | **32** | ブラウザ駆動 smoke: dashboard レンダリング、ナビゲーション、言語切替、404、health、tracker ラウンドトリップ (BF-1)、pipeline 追加と無効 URL sweep、reports 空、evaluate 手動フォールバック、config キーマスク、CV PUT XSS ストリップ、pipeline preview 400、レート制限、競合書き込み、エンティティ対応 XSS。 |
@@ -616,7 +616,7 @@ UI は **16 言語** を提供します — `en`, `es`, `pt-BR`, `ko`, `ja`, `ru
 
 Issue と PR を歓迎します。ハウスルール:
 
-- プッシュ前に `npm test` を実行してください。**1000 checks green** がバーラインです(UI に手を入れる場合は加えて 70 Playwright)。
+- プッシュ前に `npm test` を実行してください。**1822 checks green** がバーラインです(UI に手を入れる場合は加えて 90 Playwright)。
 - 非自明な変更は GSD パイプラインを経由します。[`docs/sdd/SDD-GUIDE.md`](docs/sdd/SDD-GUIDE.md) を参照してください。
 - 本リポジトリから親 `career-ops/` プロジェクト内のファイルを変更してはなりません。本プロジェクトの本質は、非侵襲的なオーバーレイであることです。ハードルールは [`CLAUDE.md`](CLAUDE.md) にあります。
 - Conventional commits: `feat`、`fix`、`refactor`、`docs`、`test`、`chore`、`perf`、`ci`。オプショナルスコープ: `feat(scan):`。Breaking change は `feat!:`。

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -370,7 +370,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23 e2e:full + 20 e2e:smoke
+└─ tests/                    # 1822 unit + 90 Playwright + 23 e2e:full + 20 e2e:smoke
    ├─ parsers.test.mjs       # markdown / pipeline / report 파서 (순수 함수)
    ├─ api.test.mjs           # 모든 엔드포인트, 임시 서버, 네트워크 없음
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -504,7 +504,7 @@ event: error    data: { message }
 ## 테스트
 
 ```bash
-npm test                       # 1000 unit/integration 테스트
+npm test                       # 1822 unit/integration 테스트
 npm run test:e2e               # 20 smoke e2e (자체 서버 부팅)
 npm run test:e2e:full          # 23 comprehensive e2e
 npm run test:e2e:browser       # 70 Playwright browser-smoke
@@ -513,11 +513,11 @@ npm run test:coverage          # `npm test`와 동일 + V8 coverage
 
 | Suite                       | Tests | 내용                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integration) | **1000** | 모든 엔드포인트, 임시 서버, 네트워크 없음. parser, scanner (mocked), runner, anthropic, security headers, XSS, JD sanitize, URL validation, path traversal, DNS-rebind, file lock, rate limit, i18n 패리티 포함. |
+| `node --test tests/*.test.mjs` (unit + integration) | **1822** | 모든 엔드포인트, 임시 서버, 네트워크 없음. parser, scanner (mocked), runner, anthropic, security headers, XSS, JD sanitize, URL validation, path traversal, DNS-rebind, file lock, rate limit, i18n 패리티 포함. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless: 모든 라우트 렌더링, 기본 플로우.                                                     |
 | `tests/e2e-comprehensive.mjs` | 23    | 전체 Playwright 워크스루: 11개 라우트 + 12개 기능 플로우.                                              |
 | `tests/playwright-smoke.mjs` (`npm run test:e2e:browser`) | **32** | 브라우저 주도 smoke: dashboard render, navigation, language switch, 404, health, tracker round-trip (BF-1), pipeline add + invalid-URL 스윕, reports empty, evaluate manual fallback, config keys masked, CV PUT XSS strip, pipeline preview 400. |
-| **합계**                   | **1000** | **0 fails, 0 flakes**                                                                                    |
+| **합계**                   | **1822** | **0 fails, 0 flakes**                                                                                    |
 
 Coverage: `--experimental-test-coverage` 기준 약 93% 라인 / 약 83% 브랜치.
 
@@ -614,7 +614,7 @@ UI는 **16개 언어**를 제공합니다 — `en`, `es`, `pt-BR`, `ko`, `ja`, `
 
 이슈와 PR을 환영합니다. 하우스 룰은 다음과 같습니다.
 
-- 푸시 전에 `npm test`를 실행합니다 — **1000 checks green**이 기준입니다(UI를 건드리는 경우 70개의 Playwright 테스트도 포함).
+- 푸시 전에 `npm test`를 실행합니다 — **1822 checks green**이 기준입니다(UI를 건드리는 경우 90개의 Playwright 테스트도 포함).
 - 비자명한 변경은 GSD 파이프라인을 거칩니다. [`docs/sdd/SDD-GUIDE.md`](docs/sdd/SDD-GUIDE.md)를 참고하십시오.
 - 이 저장소 내부에서 부모 `career-ops/` 프로젝트의 어떤 파일도 수정하지 마십시오. 핵심 가치는 이것이 비침습적 오버레이라는 점에 있습니다. [`CLAUDE.md`](CLAUDE.md)의 hard rule을 확인하십시오.
 - Conventional commits: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`. 선택적 스코프: `feat(scan):`. Breaking change: `feat!:`.

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.60.0)
+└─ tests/                    # 1822 unit + 90 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.118.2)
    ├─ parsers.test.mjs       # markdown / pipeline / report parsers (pure functions)
    ├─ api.test.mjs           # every endpoint, ephemeral server, no network
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -533,22 +533,22 @@ When `run: true` is set on `/api/deep` or `/api/mode/:slug`, the server prefers 
 ## Tests
 
 ```bash
-npm test                       # 1000 unit/integration tests
+npm test                       # 1822 unit/integration tests
 npm run test:e2e               # 20 smoke e2e (boots own server)
 npm run test:e2e:full          # 23 comprehensive e2e
-npm run test:e2e:browser       # 70 Playwright browser (smoke + full-cycle + forms + locale-sweep)
+npm run test:e2e:browser       # 90 Playwright browser (smoke + full-cycle + forms + locale-sweep ×16 + theme)
 npm run test:coverage          # same as `npm test` plus V8 coverage
 ```
 
 | Suite                       | Tests | What                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integration) | **1000** | Every endpoint, ephemeral server, no network. 110 files: parsers, scanners (mocked), runners, anthropic/openai, security headers, XSS, JD sanitize, URL validation, i18n parity, + the v1.55→v1.56 UX-fix suites. |
+| `node --test tests/*.test.mjs` (unit + integration) | **1822** | Every endpoint, ephemeral server, no network. 215 files: parsers, scanners (mocked), runners, anthropic/openai, security headers, XSS, JD sanitize, URL validation, i18n parity, + the v1.55→v1.56 UX-fix suites. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless: every route renders, basic flows.                                                     |
 | `tests/e2e-comprehensive.mjs` | 23    | Full Playwright walkthrough: 11 routes + 12 functional flows.                                              |
-| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **70** | Browser-driven: dashboard render, navigation, language switch, 404, health, tracker round-trip, pipeline add + invalid-URL sweep, reports, evaluate manual fallback, config keys masked, CV PUT XSS strip, pipeline preview 400, auto-pipeline SSE. |
-| **Total**                   | **1113** | **0 fails, 0 flakes**                                                                                    |
+| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **90** | Browser-driven: dashboard render, navigation, language switch, 404, health, tracker round-trip, pipeline add + invalid-URL sweep, reports, evaluate manual fallback, config keys masked, CV PUT XSS strip, pipeline preview 400, auto-pipeline SSE. |
+| **Total**                   | **1955** | **0 fails, 0 flakes**                                                                                    |
 
-Coverage: ~95.7% line / ~87% branch via `--experimental-test-coverage`.
+Coverage: ~93% line / ~83% branch via `--experimental-test-coverage`.
 
 Parsers are pure functions (no I/O) — tested against real data fragments from `applications.md`, `pipeline.md`, and `reports/*.md`. API tests boot the Express app on an ephemeral port and exercise every endpoint end-to-end. Scanner tests mock `fetch` so they pass even if hh.ru blocks your IP. The Playwright browser smoke runs against the in-process server and resolves Playwright via the parent project's `node_modules` — no new dependency in `web-ui/`.
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -123,7 +123,7 @@ career-ops/
 └─ web-ui/          ← to repozytorium
    ├─ server/       # Express + 15 modułów tras
    ├─ public/       # vanilla JS SPA, bez bundlera
-   └─ tests/        # 1086 testów jednostkowych + 70 Playwright + 43 e2e
+   └─ tests/        # 1822 testów jednostkowych + 90 Playwright + 43 e2e
 ```
 
 Serwer ma dwie zależności produkcyjne: `express` i `js-yaml`. Brak transpilacji, brak bundlera — cały interfejs to mniej niż 30 KB zminifikowanego kodu.
@@ -144,7 +144,7 @@ Oficjalna strona: [career-ops.org](https://career-ops.org) · Dokumentacja: [car
 ## Testy
 
 ```bash
-npm test                    # 1086 testów jednostkowych/integracyjnych
+npm test                    # 1822 testów jednostkowych/integracyjnych
 npm run test:e2e            # 20 smoke e2e
 npm run test:e2e:full       # 23 comprehensive e2e
 npm run test:e2e:browser    # 70 testów Playwright

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -370,7 +370,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit/integration + 70 Playwright e2e
+└─ tests/                    # 1822 unit/integration + 90 Playwright e2e
    ├─ parsers.test.mjs       # parsers de markdown / pipeline / report (funções puras)
    ├─ api.test.mjs           # cada endpoint, servidor efêmero, sem rede
    ├─ {ru,en}-scanner.test.mjs   # fetch mockado
@@ -505,7 +505,7 @@ Quando `run: true` é definido em `/api/deep` ou `/api/mode/:slug`, o servidor p
 ## Testes
 
 ```bash
-npm test                       # 1000 testes unit/integration
+npm test                       # 1822 testes unit/integration
 npm run test:e2e               # 20 smoke e2e (sobe o próprio server)
 npm run test:e2e:full          # 23 e2e comprehensive
 npm run test:e2e:browser       # 70 Playwright browser-smoke
@@ -514,7 +514,7 @@ npm run test:coverage          # idêntico a `npm test` mais V8 coverage
 
 | Suíte                       | Testes  | O que cobre                                                                                                |
 | --------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integration) | **1000** | Cada endpoint, servidor efêmero, sem rede. Inclui parser, scanner (mockado), runner, anthropic, security headers, XSS entity-aware, JD sanitize, validação de URL, paridade i18n, mutex de tracker, rate-limit, path-traversal e DNS rebind. |
+| `node --test tests/*.test.mjs` (unit + integration) | **1822** | Cada endpoint, servidor efêmero, sem rede. Inclui parser, scanner (mockado), runner, anthropic, security headers, XSS entity-aware, JD sanitize, validação de URL, paridade i18n, mutex de tracker, rate-limit, path-traversal e DNS rebind. |
 | `tests/e2e.mjs` (smoke)      | 20     | Playwright headless: cada rota renderiza, fluxos básicos.                                                  |
 | `tests/e2e-comprehensive.mjs` | 23    | Walkthrough Playwright completo: 11 rotas + 12 fluxos funcionais.                                          |
 | `tests/playwright-smoke.mjs` (`npm run test:e2e:browser`) | **32** | Browser-driven smoke: render do dashboard, navegação, troca de idioma, 404, health, round-trip do tracker (BF-1), pipeline add + varredura de URL inválida, reports vazio, evaluate fallback manual, config com chaves mascaradas, CV PUT XSS strip, pipeline preview 400 + cobertura WCAG 1.4.1. |
@@ -614,7 +614,7 @@ A interface inclui **16 idiomas** — `en`, `es`, `pt-BR`, `ko`, `ja`, `ru`, `zh
 
 Issues e PRs são bem-vindos. Regras da casa:
 
-- Rode `npm test` antes do push — **1000 checks verdes** é a barra (mais 70 Playwright se você mexer na UI).
+- Rode `npm test` antes do push — **1822 checks verdes** é a barra (mais 90 Playwright se você mexer na UI).
 - Mudanças não-triviais passam pelo pipeline GSD. Veja [`docs/sdd/SDD-GUIDE.md`](docs/sdd/SDD-GUIDE.md).
 - Não modifique nada no projeto pai `career-ops/` a partir deste repositório. O ponto principal é exatamente que este é um overlay não-invasivo. As hard rules estão em [`CLAUDE.md`](CLAUDE.md).
 - Conventional commits: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`. Escopo opcional: `feat(scan):`. Breaking change: `feat!:`.

--- a/README.ru.md
+++ b/README.ru.md
@@ -370,7 +370,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23 e2e:full + 20 e2e:smoke
+└─ tests/                    # 1822 unit + 90 Playwright + 23 e2e:full + 20 e2e:smoke
    ├─ parsers.test.mjs       # парсеры markdown / pipeline / отчётов (чистые функции)
    ├─ api.test.mjs           # каждая точка входа, эфемерный сервер, без сети
    ├─ {ru,en}-scanner.test.mjs   # mocked fetch
@@ -506,7 +506,7 @@ event: error    data: { message }
 ## Тесты
 
 ```bash
-npm test                       # 1000 unit/integration-теста
+npm test                       # 1822 unit/integration-теста
 npm run test:e2e               # 20 smoke e2e (поднимает собственный сервер)
 npm run test:e2e:full          # 23 comprehensive e2e
 npm run test:e2e:browser       # 70 Playwright browser-smoke
@@ -515,7 +515,7 @@ npm run test:coverage          # то же, что `npm test`, плюс V8-по�
 
 | Сьют                       | Тестов | Что покрывает                                                                                              |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (unit + integration) | **1000** | Каждый эндпоинт, эфемерный сервер, без сети. Включая парсеры, сканер (mocked), runner, anthropic, заголовки безопасности, XSS, sanitize JD, валидацию URL, защиту от DNS-rebind, состояние гонки на трекере, rate-limit, path-traversal, паритет i18n. |
+| `node --test tests/*.test.mjs` (unit + integration) | **1822** | Каждый эндпоинт, эфемерный сервер, без сети. Включая парсеры, сканер (mocked), runner, anthropic, заголовки безопасности, XSS, sanitize JD, валидацию URL, защиту от DNS-rebind, состояние гонки на трекере, rate-limit, path-traversal, паритет i18n. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright headless: каждый маршрут рендерится, базовые сценарии работают.                                 |
 | `tests/e2e-comprehensive.mjs` | 23    | Полный Playwright-walkthrough: 11 маршрутов + 12 функциональных сценариев.                                 |
 | `tests/playwright-smoke.mjs` (`npm run test:e2e:browser`) | **32** | Browser-driven smoke: рендер дашборда, навигация, переключение языка, 404, health, tracker round-trip (BF-1), pipeline add + invalid-URL sweep, пустые reports, evaluate manual fallback, маскирование ключей в config, XSS-strip на PUT CV, pipeline preview 400. |
@@ -614,7 +614,7 @@ russian_portals:
 
 Issues и PR приветствуются. Правила:
 
-- Перед push выполняйте `npm test` — **1000 проверок green** — это минимальная планка (плюс 70 Playwright, если изменения касаются UI).
+- Перед push выполняйте `npm test` — **1822 проверок green** — это минимальная планка (плюс 90 Playwright, если изменения касаются UI).
 - Нетривиальные изменения проходят через GSD-конвейер. См. [`docs/sdd/SDD-GUIDE.md`](docs/sdd/SDD-GUIDE.md).
 - Не модифицируйте ничего в родительском `career-ops/` из этого репозитория. Смысл проекта именно в том, что это неинвазивный overlay. Жёсткие правила — в [`CLAUDE.md`](CLAUDE.md).
 - Conventional commits: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`. Опциональный scope: `feat(scan):`. Breaking change: `feat!:`.

--- a/README.tr.md
+++ b/README.tr.md
@@ -400,7 +400,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 birim + 70 Playwright + 23/23 e2e:full + 20 e2e:smoke (temel @ v1.60.0)
+└─ tests/                    # 1822 birim + 90 Playwright + 23/23 e2e:full + 20 e2e:smoke (baseline @ v1.118.2)
    ├─ parsers.test.mjs       # markdown / pipeline / rapor ayrıştırıcıları (saf fonksiyonlar)
    ├─ api.test.mjs           # her uç nokta, geçici sunucu, ağ yok
    ├─ {ru,en}-scanner.test.mjs   # taklit edilmiş fetch
@@ -531,7 +531,7 @@ event: error    data: { message }
 ## Testler
 
 ```bash
-npm test                       # 1000 birim/entegrasyon testi
+npm test                       # 1822 birim/entegrasyon testi
 npm run test:e2e               # 20 smoke e2e (kendi sunucusunu başlatır)
 npm run test:e2e:full          # 23 kapsamlı e2e
 npm run test:e2e:browser       # 70 Playwright tarayıcı (smoke + full-cycle + forms + locale-sweep)
@@ -540,13 +540,13 @@ npm run test:coverage          # `npm test` ile aynı, artı V8 kapsamı
 
 | Paket                       | Test | Ne                                                                                                       |
 | --------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
-| `node --test tests/*.test.mjs` (birim + entegrasyon) | **1000** | Her uç nokta, geçici sunucu, ağ yok. 110 dosya: ayrıştırıcılar, tarayıcılar (taklit edilmiş), çalıştırıcılar, anthropic/openai, güvenlik başlıkları, XSS, iş tanımı temizleme, URL doğrulama, i18n eşitliği, + v1.55→v1.56 UX-düzeltme paketleri. |
+| `node --test tests/*.test.mjs` (birim + entegrasyon) | **1822** | Her uç nokta, geçici sunucu, ağ yok. 215 dosya: ayrıştırıcılar, tarayıcılar (taklit edilmiş), çalıştırıcılar, anthropic/openai, güvenlik başlıkları, XSS, iş tanımı temizleme, URL doğrulama, i18n eşitliği, + v1.55→v1.56 UX-düzeltme paketleri. |
 | `tests/e2e.mjs` (smoke)      | 20    | Playwright başsız: her rota render edilir, temel akışlar.                                                     |
 | `tests/e2e-comprehensive.mjs` | 23    | Tam Playwright gezintisi: 11 rota + 12 işlevsel akış.                                              |
-| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **70** | Tarayıcı güdümlü: dashboard render, gezinme, dil değiştirme, 404, health, tracker gidiş-dönüşü, pipeline ekleme + geçersiz-URL taraması, raporlar, evaluate manuel yedeği, config anahtarları maskeli, CV PUT XSS temizleme, pipeline preview 400, auto-pipeline SSE. |
-| **Toplam**                   | **1113** | **0 başarısızlık, 0 kararsızlık**                                                                                    |
+| `npm run test:e2e:browser` (`playwright-smoke` + `playwright-full-cycle` + `playwright-forms` + `playwright-locale-sweep`) | **90** | Tarayıcı güdümlü: dashboard render, gezinme, dil değiştirme, 404, health, tracker gidiş-dönüşü, pipeline ekleme + geçersiz-URL taraması, raporlar, evaluate manuel yedeği, config anahtarları maskeli, CV PUT XSS temizleme, pipeline preview 400, auto-pipeline SSE. |
+| **Toplam**                   | **1955** | **0 başarısızlık, 0 kararsızlık**                                                                                    |
 
-Kapsam: `--experimental-test-coverage` aracılığıyla ~%95.7 satır / ~%87 dal.
+Kapsam: `--experimental-test-coverage` aracılığıyla ~%93 satır / ~%83 dal.
 
 Ayrıştırıcılar saf fonksiyonlardır (G/Ç yok) — `applications.md`, `pipeline.md` ve `reports/*.md` dosyalarından gerçek veri parçalarına karşı test edilir. API testleri, Express uygulamasını geçici bir portta başlatır ve her uç noktayı uçtan uca çalıştırır. Tarayıcı testleri `fetch`'i taklit eder, böylece hh.ru IP'nizi engellese bile geçerler. Playwright tarayıcı smoke'u, süreç içi sunucuya karşı çalışır ve Playwright'ı üst projenin `node_modules`'ı aracılığıyla çözer — `web-ui/` içinde yeni bağımlılık yok.
 

--- a/README.uk.md
+++ b/README.uk.md
@@ -123,7 +123,7 @@ career-ops/
 └─ web-ui/          ← це репозиторій
    ├─ server/       # Express + 15 модулів маршрутів
    ├─ public/       # vanilla JS SPA, без бандлера
-   └─ tests/        # 1086 unit + 70 Playwright + 43 e2e
+   └─ tests/        # 1822 unit + 90 Playwright + 43 e2e
 ```
 
 Сервер має дві виробничі залежності: `express` та `js-yaml`. Жодного transpile, жодного бандлера — весь UI займає менше 30 KB у мінімізованому вигляді.
@@ -144,7 +144,7 @@ career-ops/
 ## Тести
 
 ```bash
-npm test                    # 1086 unit/integration-тестів
+npm test                    # 1822 unit/integration-тестів
 npm run test:e2e            # 20 smoke e2e
 npm run test:e2e:full       # 23 comprehensive e2e
 npm run test:e2e:browser    # 70 тестів Playwright

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -517,7 +517,7 @@ npm run test:coverage          # 同 `npm test`,附加 V8 覆盖率
 | `tests/e2e.mjs`(smoke)      | 20    | Playwright headless:每个路由可渲染,基础流程。                                                            |
 | `tests/e2e-comprehensive.mjs` | 23    | 完整 Playwright walkthrough:11 个路由 + 12 个功能流程。                                                   |
 | `tests/playwright-smoke.mjs`(`npm run test:e2e:browser`) | **12** | 浏览器驱动的烟雾:dashboard 渲染、导航、语言切换、404、health、tracker 往返(BF-1)、pipeline 添加 + 无效 URL 扫描、reports 空、evaluate 手动回退、config keys 遮蔽、CV PUT XSS 清理、pipeline preview 400。 |
-| **总计**                   | **1000** | **0 失败,0 flake**                                                                                       |
+| **总计**                   | **1822** | **0 失败,0 flake**                                                                                       |
 
 覆盖率:通过 `--experimental-test-coverage` 得 ~93% 行 / ~83% 分支。
 
@@ -613,7 +613,7 @@ Claude Code 中现有的 `/career-ops apply` Playwright 表单填写流程,仍�
 
 欢迎 issues 与 PR。家规如下:
 
-- 推送前先跑 `npm test` —— **1000 项全绿** 是底线(触碰 UI 时再加上 70 个 Playwright)。
+- 推送前先跑 `npm test` —— **1822 项全绿** 是底线(触碰 UI 时再加上 90 个 Playwright)。
 - 非平凡变更走 GSD 流水线。见 [`docs/sdd/SDD-GUIDE.md`](docs/sdd/SDD-GUIDE.md)。
 - 不要从本仓库内修改父 `career-ops/` 项目的任何文件。这是一个非侵入式叠加层 —— 这是整件事的意义所在。硬性规则见 [`CLAUDE.md`](CLAUDE.md)。
 - 约定式提交:`feat`、`fix`、`refactor`、`docs`、`test`、`chore`、`perf`、`ci`。可选 scope:`feat(scan):`。破坏性变更:`feat!:`。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -370,7 +370,7 @@ career-ops-ui/
 │  ├─ sdd/{SDD-GUIDE,CONVENTIONS}.md
 │  ├─ architecture/{OVERVIEW,SERVER,FRONTEND,API,DATA-FLOWS}.md
 │  └─ reviews/REVIEW-*.md
-└─ tests/                    # 1000 unit + 70 Playwright + 23 e2e:full + 20 e2e:smoke
+└─ tests/                    # 1822 unit + 90 Playwright + 23 e2e:full + 20 e2e:smoke
    ├─ parsers.test.mjs       # markdown / pipeline / report 解析器(純函式)
    ├─ api.test.mjs           # 每個端點、暫時性伺服器、無網路
    ├─ {ru,en}-scanner.test.mjs   # 已 mock 的 fetch
@@ -507,7 +507,7 @@ event: error    data: { message }
 ## 測試
 
 ```bash
-npm test                       # 1000 個 unit/integration 測試
+npm test                       # 1822 個 unit/integration 測試
 npm run test:e2e               # 20 個 smoke e2e(自行啟動伺服器)
 npm run test:e2e:full          # 23 個 comprehensive e2e
 npm run test:e2e:browser       # 70 個 Playwright 瀏覽器 smoke
@@ -516,7 +516,7 @@ npm run test:coverage          # 同 `npm test`,加上 V8 coverage
 
 | Suite                       | 測試數 | 內容                                                                                                         |
 | --------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ |
-| `node --test tests/*.test.mjs`(unit + integration) | **1000** | 每個端點、暫時性伺服器、無網路。涵蓋解析器、scanner(已 mock)、runner、anthropic、CSP / 安全 header、實體感知 XSS、JD sanitize、URL 驗證、SSRF redirect rebind、檔案互斥下的並行 tracker 寫入、`llmRateLimit`、路徑統一 sanitization、i18n parity。 |
+| `node --test tests/*.test.mjs`(unit + integration) | **1822** | 每個端點、暫時性伺服器、無網路。涵蓋解析器、scanner(已 mock)、runner、anthropic、CSP / 安全 header、實體感知 XSS、JD sanitize、URL 驗證、SSRF redirect rebind、檔案互斥下的並行 tracker 寫入、`llmRateLimit`、路徑統一 sanitization、i18n parity。 |
 | `tests/e2e.mjs`(smoke)      | 20    | Playwright headless:每條路由可渲染、基本流程。                                                              |
 | `tests/e2e-comprehensive.mjs` | 23    | 完整 Playwright walkthrough:11 條路由 + 12 條功能流程。                                                      |
 | `tests/playwright-smoke.mjs`(`npm run test:e2e:browser`) | **32** | 瀏覽器驅動 smoke:dashboard render、navigation、語言切換、404、health、tracker round-trip(BF-1)、pipeline add + 無效 URL 掃描、reports empty、evaluate 手動 fallback、config 金鑰遮罩、CV PUT XSS strip、pipeline preview 400、WCAG 1.4.1 視覺冗餘線索回歸。 |
@@ -616,7 +616,7 @@ Claude Code 中既有的 `/career-ops apply` Playwright 表單填寫流程,仍�
 
 歡迎 Issues 與 PRs。House rules:
 
-- 推送前執行 `npm test` — **1000 項檢查綠燈**為門檻(若觸碰 UI 則加上 70 個 Playwright)。
+- 推送前執行 `npm test` — **1822 項檢查綠燈**為門檻(若觸碰 UI 則加上 90 個 Playwright)。
 - 非微不足道的變更請走 GSD pipeline。詳見 [`docs/sdd/SDD-GUIDE.md`](docs/sdd/SDD-GUIDE.md)。
 - 不要從本儲存庫內修改父專案 `career-ops/` 內的任何東西。重點在於這是一個非侵入式 overlay。Hard rules 位於 [`CLAUDE.md`](CLAUDE.md)。
 - Conventional commits:`feat`、`fix`、`refactor`、`docs`、`test`、`chore`、`perf`、`ci`。選填 scope:`feat(scan):`。Breaking change:`feat!:`。

--- a/qa/QA-REGRESSION-PROMPT-v1.118.2.md
+++ b/qa/QA-REGRESSION-PROMPT-v1.118.2.md
@@ -1,0 +1,47 @@
+# QA REGRESSION PROMPT — career-ops-ui **v1.118.2** (release delta driver: v1.118.1 + v1.118.2)
+
+Delta driver covering the two patch releases after the v1.118.0 parity pack. Run on top of the definitive whole-project prompt (`qa/QA-REGRESSION-PROMPT.md`); this file covers ONLY what v1.118.1–v1.118.2 added. Server: `npm start` → `http://127.0.0.1:4317`.
+
+- **Version under test:** `package.json` **1.118.2** · `parentVersion` **1.18.0** · **31 route modules** · **59 adapters (54 EN + 5 RU)**.
+- **Baseline:** **1822** `node --test` cases (1817 → +1 hh-451 → +4 site-script guards) · CHANGELOG/README parity ×16 at v1.118.2.
+
+---
+
+## §1 — v1.118.1: hh.ru HTTP 451 geo-block handling
+
+Background: hh.ru now serves **HTTP 451** (regional legal block) to non-Russian IPs on its public search pages (`hh.ru/search/vacancy`); the JSON API has long been 403 for every programmatic client. A 451 from your network is **environment, not a regression**.
+
+1. Unit (`tests/ru-scanner.test.mjs`): `searchHH` with a stubbed 451 response throws with `err.geoBlocked === true && err.status === 451` (mirrors the existing 403 case).
+2. Run behavior: on the FIRST 451 (or 403) the RU scan **disables hh.ru for the rest of the run** — remaining queries must NOT hit hh again; the other RU sources (habr / trudvsem / getmatch / geekjob) still complete.
+3. Log contract (`ru-scanner.mjs`): the disable line names the actual cause — 451 gets the geo hint (`…geo-blocks requests from outside Russia (HTTP 451) — scan via a Russian IP / VPN exit node. See help §7.`), 403 keeps the anti-bot wording. Server messages stay English-by-policy.
+4. Help ×16: the `### hh.ru` subsection under §7 is rewritten in ALL 16 bundles — heading now says a Russian IP is required since July 2026; the old "works from any IP" claim must be gone everywhere. H2/H3 counts unchanged (28 / 103).
+5. Live (optional, network-dependent): from a non-RU IP, an RU scan shows one `⚠ hh.ru disabled for this run (hh.ru: HTTP 451)` stderr pair and zero further hh requests.
+
+## §2 — v1.118.2: landing follow-up (PR #118 review closeout)
+
+1. `site/README.md` says **Astro 7** (matches `site/package.json` `astro ^7.0.7` — the #116 security upgrade closing 5 GHSAs + esbuild).
+2. `site/scripts/generate-og.mjs` has no unused `writeFileSync` import (CodeQL #396 fixed at source; #395 dismissed with rationale — fixed-URL build-time star snapshot into a gitignored artifact).
+3. **Site-script guards** (`tests/site-scripts.test.mjs`, +4, CI-isolated mkdtemp fixture — no parent project, no network):
+   - check-i18n passes on a 16-locale parity fixture;
+   - check-i18n **fails (exit ≠ 0)** when a locale is missing a key;
+   - check-i18n **fails** when a locale dictionary file is missing entirely;
+   - sync-assets source invariant: no write destination is ROOT-derived (`join(ROOT`/`resolve(ROOT`/`ROOT +` all trip the guard) — landing writes never leave `site/`.
+4. Pages workflow (`.github/workflows/deploy-pages.yml`): build step runs `npx astro check` + `node scripts/check-i18n.mjs` before `npm run build`, on **Node 22** (Astro 7 requires ≥22.12); paths-filter unchanged (`site/**`, `docs/help/**`, `images/dashboard-*.png`).
+5. CLAUDE.md carve-out: the no-build rule for `public/` explicitly records the `site/` exception (CI-only build; nothing in `server/`/`public/` imports from `site/`).
+
+## §3 — Release mechanics ×16
+
+```bash
+node scripts/check-changelog-parity.mjs   # "all 15 locales at v1.118.2"
+npm test                                  # ≥1822 green — run raw, check $?, never `| grep`
+```
+
+- CHANGELOG ×16 carry both `## [1.118.1]` (hh 451) and `## [1.118.2]` (landing follow-up) entries.
+- README ×16: release badge v1.118.2, tests badge 1822.
+- `qa/REGRESSION-FINAL.md` baseline block: v1.118.2 · unit ≥ 1822 · 28 H2 / 103 H3 · 59 adapters.
+- GitHub Release latest = `v1.118.2`; GitHub Packages `@fighter90/career-ops-ui` dist-tag `latest` = `1.118.2`.
+- Live landing (`https://cvstart.org`) facts show **v1.118.2 / 1,822** (redeployed post-release; facts.json is a build-time snapshot — stale numbers there mean the Pages workflow wasn't re-run, not a code bug).
+
+## §4 — Sign-off
+
+`npm test` ≥1822 green · `npm run test:ci` green · Playwright suite green · CI matrix (Node 18/20/22 + CodeQL + dependency review) green on PRs #117–#119. CodeQL notes: `js/missing-rate-limiting` on llmRateLimit-guarded routes stays the known categorical FP; the two site-script alerts (#395/#396) are resolved as described in §2.

--- a/qa/QA-REGRESSION-PROMPT.md
+++ b/qa/QA-REGRESSION-PROMPT.md
@@ -1,21 +1,21 @@
-# QA REGRESSION PROMPT — career-ops-ui **v1.118.0** (DEFINITIVE · WHOLE PROJECT · ALL LANGUAGES)
+# QA REGRESSION PROMPT — career-ops-ui **v1.118.2** (DEFINITIVE · WHOLE PROJECT · ALL LANGUAGES)
 
-Single standalone hand-off for a QA tester (human or agent) to verify the **entire** career-ops-ui build end-to-end, in **all 16 languages**, covering every feature shipped from **v1.76.0 through v1.118.0**. Walking this top-to-bottom signs off the build without needing the rest of the `qa/` tree. §§ below cover the v1.76→v1.97 surface; **§14 (at the end) covers everything added v1.98→v1.118 (incl. the v1.111 CodeQL backlog closeout)**.
+Single standalone hand-off for a QA tester (human or agent) to verify the **entire** career-ops-ui build end-to-end, in **all 16 languages**, covering every feature shipped from **v1.76.0 through v1.118.2**. Walking this top-to-bottom signs off the build without needing the rest of the `qa/` tree. §§ below cover the v1.76→v1.97 surface; **§14 (at the end) covers everything added v1.98→v1.118.2 (incl. the v1.111 CodeQL backlog closeout, the hh.ru-451 fix and the cvstart.org landing)**.
 
-- **Version under test:** `package.json` **1.118.0** · **31 route modules** · **59 adapters (54 EN + 5 RU)**.
-- **Baseline:** **1817** `node --test` cases · Playwright (smoke + full-cycle + forms + **locale-sweep ×16** + theme-toggle) · 20 smoke E2E · 23 comprehensive E2E · CI matrix green on Node 18/20/22 + Playwright + CodeQL (backlog closed 167→0, all real findings fixed at source (v1.111)).
+- **Version under test:** `package.json` **1.118.2** · **31 route modules** · **59 adapters (54 EN + 5 RU)**.
+- **Baseline:** **1822** `node --test` cases · Playwright (smoke + full-cycle + forms + **locale-sweep ×16** + theme-toggle) · 20 smoke E2E · 23 comprehensive E2E · CI matrix green on Node 18/20/22 + Playwright + CodeQL (backlog closed 167→0, all real findings fixed at source (v1.111)).
 - **Server:** `npm start` → `http://127.0.0.1:4317`.
-- **Sibling docs:** `qa/QA-REGRESSION-PROMPT-v1.1XX.0.md` (per-release delta drivers, v1.90–v1.118 incl. the v1.110 milestone snapshot + per-version v1.111/v1.112/v1.113/v1.117/v1.118) · `qa/UX-AUDIT-PROMPT.md` (UX audit) · `qa/FUNCTIONALITY-CHECK.md` (functional correctness) · `qa/DESIGNER-EXPORT-PROMPT.md` (design export) · `REGRESSION-FINAL.md` (invariant ledger).
+- **Sibling docs:** `qa/QA-REGRESSION-PROMPT-v1.1XX.0.md` (per-release delta drivers, v1.90–v1.118.2 incl. the v1.110 milestone snapshot + per-version v1.111/v1.112/v1.113/v1.117/v1.118.0/v1.118.2) · `qa/UX-AUDIT-PROMPT.md` (UX audit) · `qa/FUNCTIONALITY-CHECK.md` (functional correctness) · `qa/DESIGNER-EXPORT-PROMPT.md` (design export) · `REGRESSION-FINAL.md` (invariant ledger).
 
 ---
 
 ## §0 — Gates (all must be green before sign-off)
 
 ```bash
-npm test                                    # full suite (≥1817 cases)
+npm test                                    # full suite (≥1822 cases)
 npm run test:ci                             # unit + check-no-also + check-changelog-parity + i18n-audit
 node tools/i18n-audit.mjs                   # "no hard failures — dictionary is clean"
-node scripts/check-changelog-parity.mjs     # "all 15 locales at v1.118.0" (EN + 15 = 16 files)
+node scripts/check-changelog-parity.mjs     # "all 15 locales at v1.118.2" (EN + 15 = 16 files)
 npm run test:coverage                       # ≥80% line / ≥75% branch (baseline ~96/~86)
 npm run test:e2e:browser                    # playwright smoke + full-cycle + forms + locale-sweep(16) + theme-toggle
 npm run test:e2e && npm run test:e2e:full   # smoke (20) + comprehensive (23) E2E
@@ -38,6 +38,8 @@ node scripts/portals-health-check.mjs       # portals.yml reachability (informat
 9. **Two scanner registries — don't conflate.** `server/lib/sources/registry.mjs` (auto-discovered `meta`) drives the `#/scan` *dropdown* + RU dispatch; `server/lib/portals/registry.mjs` (`ALL_ADAPTERS`, hand-maintained) is what the EN scanner walks to *fetch*. A new EN board needs BOTH.
 10. **Playwright headless shell:** missing → `npx playwright install chromium-headless-shell` (env gap, not a regression).
 11. **Cross-realm vm arrays:** spread (`[...]`) a vm-realm array before `deepEqual` against a main-realm literal.
+12. **hh.ru from a non-Russian IP returns HTTP 451** (geo/legal block, July 2026) — the scan disabling hh with the VPN hint is CORRECT behavior, not a bug. Don't file it; don't "fix" it.
+13. **`site/` has a build step — that's the recorded carve-out, not a violation.** The no-bundler rule still applies to `public/`; nothing in `server/`/`public/` may import from `site/`.
 12. **Live-LLM routes cascade or fall back.** The AI routes (evaluate/deep/market/career-plan/orientation/cv-studio/memory-suggest/two-pager-draft/mock-interview/networking) run the shared `runActiveProvider` cascade; with no key they return an honest copy-paste **manual prompt** (mode `manual`), never a fabricated answer. Test both paths.
 13. **i18n key duplication is invisible to parity.** Duplicate `'key':` lines in a locale dict pass the snapshot (last-wins) but are a CodeQL `js/duplicate-property` defect — grep each dict for dup keys after any fan-out.
 
@@ -168,18 +170,18 @@ Locales: `en, es, pt-BR, ko, ja, ru, zh-CN, zh-TW, fr, pl, uk, da, ar, de, it, t
 
 ## §7 — Docs / branding / release mechanics
 
-- **README ×16** + **CHANGELOG ×16** at **v1.118.0** (parity gate green — `node scripts/check-changelog-parity.mjs`); each language switcher lists all 16. README "Latest release" blurb describes the current release; localized "New:" trailers are native per locale (no English leak).
+- **README ×16** + **CHANGELOG ×16** at **v1.118.2** (parity gate green — `node scripts/check-changelog-parity.mjs`); each language switcher lists all 16. README "Latest release" blurb describes the current release; localized "New:" trailers are native per locale (no English leak).
 - **Help ×16** hold the gated **28 H2 / 103 H3**; §17 says **59 adapters**.
 - **Branding:** radar-icon favicon set + sidebar logo; app name **career-ops-ui**. Parent `career-ops` references intentionally unchanged.
-- **Release:** `package.json` 1.118.0; footer reads `/api/health`; `parentVersion` = 1.18.0 (independent; semver only). Tag `v1.118.0` → `release.yml`; **Publish is triggered by the GitHub Release event** (do NOT also `gh workflow run` — a parallel manual dispatch races the release-triggered run to an E409; the workflow is E409-tolerant) → GitHub Packages. **30 route modules.**
+- **Release:** `package.json` 1.118.2; footer reads `/api/health`; `parentVersion` = 1.18.0 (independent; semver only). Tag `v1.118.2` → `release.yml`; **Publish is triggered by the GitHub Release event** (do NOT also `gh workflow run` — a parallel manual dispatch races the release-triggered run to an E409; the workflow is E409-tolerant) → GitHub Packages. **31 route modules.**
 
 ---
 
 ## §8 — Exit criteria
 - Every (page × control × 16 languages) PASS or a logged FAIL→fix (one-fix-per-release; HIGH → MEDIUM → LOW).
-- `npm test` ≥ **1817** green; `npm run test:ci` green; coverage ≥ floor; Playwright (locale-sweep ×16) green; CI matrix green; **CodeQL backlog closed (167→0; final 6 fixed at source in v1.111 — sanitizer escape belt, type-confusion coercion, dynamic-dispatch removal)**.
+- `npm test` ≥ **1822** green; `npm run test:ci` green; coverage ≥ floor; Playwright (locale-sweep ×16) green; CI matrix green; **CodeQL backlog closed (167→0; final 6 fixed at source in v1.111 — sanitizer escape belt, type-confusion coercion, dynamic-dispatch removal)**.
 - Zero console errors; no RTL leak; no untranslated shipped key; no duplicate dict keys; favicon/icon endpoints 200.
-- All §2 deltas verified live (scanner 59 adapters incl. Dassault + the v1.118 parity batch; the eight v1.85–v1.96 pages; the v1.97 audit fixes) **and all §14 additions (v1.98–v1.118)**.
+- All §2 deltas verified live (scanner 59 adapters incl. Dassault + the v1.118 parity batch; the eight v1.85–v1.96 pages; the v1.97 audit fixes) **and all §14 additions (v1.98–v1.118.2)**.
 
 ---
 
@@ -205,5 +207,7 @@ Locales: `en, es, pt-BR, ko, ja, ru, zh-CN, zh-TW, fr, pl, uk, da, ar, de, it, t
 | 16 | **Usage meter rework + widget E2E (v1.116.0)** | The usage meter is **pinned to the bottom of the sidebar** (fixed, full width) and pads the sidebar so the **menu is never covered**; **refreshes live** (15 s + tab-focus + route); rows show real `<tokens> · <est. cost>` (bars vs 30d), not a 100% share. `cv-import.mjs` reads the buffer size behind a `typeof` barrier (closes CodeQL #384). First real-browser **E2E** (`tests/playwright-widgets.mjs`) drives both persistent widgets. See `qa/QA-REGRESSION-PROMPT-v1.116.0.md`. |
 | 17 | **Parent parity pack (v1.117.0)** | Six parent capabilities in the UI: `#/followup` **cadence board** (urgency chips + table + Seed button; fail-soft without the parent), `#/stats` **Rejection patterns** tab (outcome mix + recommendations + per-ATS-vendor advance rate), CV Studio **Add to CV** card (grounded bullets from URL/text — SSRF-gated fetch, suggestions only, NO writes), **4 new scan providers** (beesite/HigherEdJobs/JibeApply/softgarden → **50 adapters, 45 EN + 5 RU**), Apply **knock-out pre-scan** step, `/api/run/reconcile`. 41 new i18n keys ×16. See `qa/QA-REGRESSION-PROMPT-v1.117.0.md`. |
 | 18 | **Parent v1.18.0 parity (v1.118.0)** | **9 new scan providers** (csod/Phenom/Radancy/Deutsche Bahn/EchoJobs/TKMS/Heckler & Koch/Rheinmetall/LaraJobs → **59 adapters, 54 EN + 5 RU**) + **Lever EU** (`jobs.eu.lever.co`); canonical **`Hired`** status (whitelist + celebratory badge + job-landed banner + funnel/conversions); `#/stats` **Lifetime** tab relaying parent `stats.mjs` + `salary-gap.mjs` (`GET /api/stats/lifetime`, `GET /api/stats/salary-gap` — zero-token, fail-soft); 28 i18n keys ×16; help §14/§26 ×16 (**103 H3**). See `qa/QA-REGRESSION-PROMPT-v1.118.0.md`. |
+| 19 | **hh.ru 451 geo-block (v1.118.1)** | hh.ru serves **HTTP 451** to non-RU IPs on the public search pages (July 2026). `searchHH` flags 451 as `geoBlocked` (like 403) → RU scan **disables hh after the first block** with a per-cause log hint (451 → Russian IP / VPN, see help §7; 403 → anti-bot). Help `### hh.ru` subsection rewritten ×16 ("works from any IP" is gone). A 451 from a non-RU network is ENVIRONMENT, not a regression. See `qa/QA-REGRESSION-PROMPT-v1.118.2.md` §1. |
+| 20 | **cvstart.org marketing landing (v1.118.0–.2, PRs #116/#118/#119)** | `site/` — a SEPARATE Astro 7 static artifact (33 pages: 16 locales × home+help + 404), built ONLY in CI (`deploy-pages.yml`, Node 22, paths-filtered; the no-build rule still owns `public/` — carve-out recorded in CLAUDE.md). Build gates in-workflow: `npx astro check` + `scripts/check-i18n.mjs` (16×190 keys). Guards in the main suite: `tests/site-scripts.test.mjs` (+4 — parity gate fails on broken dict; sync-assets never writes outside `site/`). Live: `https://cvstart.org` (EN `/` + 15 prefixes, `/ar/` RTL), facts (version/tests/adapters) are a BUILD-TIME snapshot — stale facts mean redeploy Pages, not a code bug. `cvstart.ru` → `cvstart.org/ru/<path>` via the separate `cvstart-ru-redirect` repo. |
 
-**New routes since v1.97:** `POST /api/portals/health`, `POST /api/export/docx`, `POST /api/cv-studio/tailor`, `POST /api/docs-assistant/ask`, `GET /api/cli-detect`, `GET /api/logo`, `GET /api/usage` (30 route modules total). **New i18n:** every one is present + translated in all **16** locales (`i18n-coverage` + `i18n-locale-files` green). **New Help:** each surfaced in `docs/help/*` (in-place for two-pager/CV-Studio/settings/health/scan/pipeline; §-level for portals/docs-assistant where applicable).
+**New routes since v1.97:** `POST /api/portals/health`, `POST /api/export/docx`, `POST /api/cv-studio/tailor`, `POST /api/docs-assistant/ask`, `GET /api/cli-detect`, `GET /api/logo`, `GET /api/usage`; v1.117 added followup (31 route modules total). **New i18n:** every one is present + translated in all **16** locales (`i18n-coverage` + `i18n-locale-files` green). **New Help:** each surfaced in `docs/help/*` (in-place for two-pager/CV-Studio/settings/health/scan/pipeline; §-level for portals/docs-assistant where applicable).


### PR DESCRIPTION
1. **`qa/QA-REGRESSION-PROMPT-v1.118.2.md`** — per-release delta driver covering v1.118.1 (hh.ru 451: unit contract, run-disable behavior, per-cause log, help ×16) and v1.118.2 (landing follow-up: Astro 7 reconcile, +4 site-script guards, CodeQL closeout) + the ×16 release-mechanics checks.
2. **`qa/QA-REGRESSION-PROMPT.md`** (definitive) — now covers the entire functionality v1.76→v1.118.2: baselines bumped to 1822, §14 gains rows 19 (hh 451) and 20 (the cvstart.org landing artifact — build gates, carve-out, facts-are-a-build-snapshot rule), two new methodology footguns (451 = environment, not a bug; site/ build carve-out).
3. **README ×16** — the Tests section was frozen at the v1.55 era (1000 unit / 70 Playwright / **1113 total** / 95.7% coverage) while the badge said 1822 — reader-visible drift flagged during post-drafting. Actualized to **1822 / 90 / 1955 / ~93% line / ~83% branch / 215 test files** in all 16 locales (per-locale number formats like «1 000» handled).

Docs-only; no version bump (follows the #115 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)