### PR TITLE
fix(scan): null-guard matches() in the agenticjobs and wttj adapters

### DIFF
--- a/server/lib/portals/adapters/agenticjobs.mjs
+++ b/server/lib/portals/adapters/agenticjobs.mjs
@@ -23,6 +23,7 @@ export const agenticjobsAdapter = {
   id: 'agenticjobs',
   label: 'Agentic Jobs',
   matches(company) {
+    if (!company) return false;
     return company.provider === 'agenticjobs';
   },
   buildEndpoint(company) {

--- a/server/lib/portals/adapters/wttj.mjs
+++ b/server/lib/portals/adapters/wttj.mjs
@@ -23,6 +23,7 @@ export const wttjAdapter = {
   id: 'wttj',
   label: 'Welcome to the Jungle',
   matches(company) {
+    if (!company) return false;
     return company.provider === 'wttj';
   },
   buildEndpoint(company) {


### PR DESCRIPTION
AI-review follow-up on #136 — the other three v1.124.0 adapters guard `if (!company) return false;`; these two now match. No behaviour change for registry callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)