### PR TITLE
fix(scan): detect Hangzhou & co in the Country filter for Chinese tech boards

### DIFF
--- a/public/js/lib/countries.js
+++ b/public/js/lib/countries.js
@@ -109,6 +109,12 @@
     sydney: 'au', melbourne: 'au', auckland: 'nz', bangalore: 'in', bengaluru: 'in', mumbai: 'in',
     delhi: 'in', hyderabad: 'in', pune: 'in', tokyo: 'jp', osaka: 'jp', seoul: 'kr',
     beijing: 'cn', shanghai: 'cn', shenzhen: 'cn', taipei: 'tw', jakarta: 'id', 'kuala lumpur': 'my',
+    // v1.125.x — Chinese tech-board sources (Alibaba/Meituan/Tencent) emit
+    // more mainland cities, often in CJK. Alibaba HQ is Hangzhou.
+    hangzhou: 'cn', guangzhou: 'cn', chengdu: 'cn', nanjing: 'cn', wuhan: 'cn',
+    suzhou: 'cn', xiamen: 'cn', hefei: 'cn',
+    '北京': 'cn', '上海': 'cn', '深圳': 'cn', '杭州': 'cn', '广州': 'cn',
+    '成都': 'cn', '南京': 'cn', '武汉': 'cn', '苏州': 'cn',
     manila: 'ph', bangkok: 'th', hanoi: 'vn', 'ho chi minh': 'vn', dubai: 'ae', 'abu dhabi': 'ae',
     riyadh: 'sa', 'tel aviv': 'il', cairo: 'eg', lagos: 'ng', nairobi: 'ke',
     'cape town': 'za', johannesburg: 'za',

--- a/tests/countries.test.mjs
+++ b/tests/countries.test.mjs
@@ -28,6 +28,10 @@ test('Countries API surface + every country has code/name/flag', () => {
 
 test('detectCountry: explicit country names + aliases', () => {
   assert.equal(C.detectCountry('Berlin, Germany').code, 'de');
+  // v1.125.x — Chinese tech-board sources emit mainland cities, often in CJK.
+  assert.equal(C.detectCountry('Hangzhou').code, 'cn');
+  assert.equal(C.detectCountry('杭州').code, 'cn');
+  assert.equal(C.detectCountry('Guangzhou, Guangdong').code, 'cn');
   assert.equal(C.detectCountry('Remote (Deutschland)').code, 'de');
   assert.equal(C.detectCountry('New York, NY, USA').code, 'us');
   assert.equal(C.detectCountry('London, United Kingdom').code, 'gb');


### PR DESCRIPTION
The #/scan Country dropdown is self-building from detected locations, but the city-alias map lacked Hangzhou (Alibaba HQ), other mainland cities, and CJK spellings — postings from the v1.119/v1.124 Chinese tech-board sources fell out of the filter. Adds 8 pinyin + 9 CJK city aliases; +3 assertions in tests/countries.test.mjs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)