### PR TITLE
chore(site): close AI-review nits on the sources section

### DIFF
--- a/site/src/components/Sources.astro
+++ b/site/src/components/Sources.astro
@@ -61,8 +61,8 @@ const SOURCE_URLS: Record<string, string> = {
   rheinmetall: 'https://www.rheinmetall.com',
   rippling: 'https://www.rippling.com',
   rss: '',
-  successfactors: 'https://www.sap.com',
   smartrecruiters: 'https://www.smartrecruiters.com',
+  successfactors: 'https://www.sap.com',
   softgarden: 'https://softgarden.com',
   solidjobs: 'https://solid.jobs',
   teamtailor: 'https://www.teamtailor.com',
@@ -99,7 +99,7 @@ const chip =
     <ul class="mt-8 flex flex-wrap gap-2.5">
       {en.map((s) => (
         <li>
-          <a href={hrefFor(s.value)} rel="noopener nofollow" class={chip}>{s.label}</a>
+          <a href={hrefFor(s.value)} rel="noopener noreferrer nofollow" class={chip}>{s.label}</a>
         </li>
       ))}
     </ul>
@@ -107,7 +107,7 @@ const chip =
     <ul class="flex flex-wrap gap-2.5">
       {ru.map((s) => (
         <li>
-          <a href={hrefFor(s.value)} rel="noopener nofollow" class={chip}>{s.label}</a>
+          <a href={hrefFor(s.value)} rel="noopener noreferrer nofollow" class={chip}>{s.label}</a>
         </li>
       ))}
     </ul>

--- a/tests/site-sources.test.mjs
+++ b/tests/site-sources.test.mjs
@@ -33,8 +33,14 @@ test('SOURCE_URLS covers every registry source value', () => {
   const keys = new Set(
     [...astro.matchAll(/^\s{2}(?:'([^']+)'|([A-Za-z0-9_]+)):\s*'/gm)].map((m) => m[1] || m[2]),
   );
+  const urls = new Map(
+    [...astro.matchAll(/^\s{2}(?:'([^']+)'|([A-Za-z0-9_]+)):\s*'([^']*)'/gm)].map((m) => [m[1] || m[2], m[3]]),
+  );
   for (const s of SOURCES) {
     assert.ok(keys.has(s.value), `SOURCE_URLS missing '${s.value}' (${s.label}) — add its link`);
+    if (s.value === 'rss') continue; // the app's own connector links to the guide
+    const u = urls.get(s.value) || '';
+    assert.ok(u.startsWith('https://'), `SOURCE_URLS['${s.value}'] must be a non-empty https URL, got '${u}'`);
   }
 });
 


### PR DESCRIPTION
Follow-up on #140's advisory review: the drift gate now asserts a non-empty `https://` URL for every non-rss source (empty rows no longer satisfy it), SOURCE_URLS ordering restored to alphabetical, chip links add `noreferrer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)