### PR TITLE
fix(site): keep the header "Get started" CTA on one line

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -54,7 +54,7 @@ const NAV = [
       <div class="hidden sm:block">
         <GitHubButton label={t(locale, 'header.github')} />
       </div>
-      <a href={anchor('get-started')} class="btn-primary !px-5 !py-2 text-sm">{t(locale, 'header.cta')}</a>
+      <a href={anchor('get-started')} class="btn-primary shrink-0 whitespace-nowrap !px-5 !py-2 text-sm">{t(locale, 'header.cta')}</a>
       <button
         id="menu-btn"
         type="button"


### PR DESCRIPTION
The header CTA could wrap to two lines when the row tightens — now `shrink-0 whitespace-nowrap`, matching the nav-label treatment from v1.122.0. Site-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)