### PR TITLE
Fix Gemini deep research MALFORMED_FUNCTION_CALL (headless prompts)

### DIFF
--- a/server/lib/prompts.mjs
+++ b/server/lib/prompts.mjs
@@ -223,10 +223,27 @@ export function bundleProjectContext(opts = {}) {
     blocks.push(`--- ${f.label} ---\n${text}`);
   }
   if (!blocks.length) return '';
-  return [
+  const head = [
     '<project_context>',
     'You are running outside Claude Code, so the files referenced below',
     'are inlined here. Treat them as authoritative.',
+  ];
+  // Headless API runners (Gemini/Anthropic/OpenAI/…) have no tool channel.
+  // modes/_shared.md still lists WebSearch/WebFetch for Claude Code — without
+  // this override Gemini often emits finishReason MALFORMED_FUNCTION_CALL and
+  // /api/deep returns HTTP 502 with empty text.
+  if (opts.headless) {
+    head.push(
+      '',
+      'IMPORTANT — headless API session (no tools):',
+      'You do NOT have access to browsing, search, Playwright, or file writing.',
+      'Ignore any tool instructions or tool tables in the mode files below.',
+      'Write the full answer from the inlined context + your knowledge; mark',
+      'time-sensitive claims as estimates. The server persists the output.',
+    );
+  }
+  return [
+    ...head,
     '',
     blocks.join('\n\n'),
     '</project_context>',
@@ -342,10 +359,21 @@ ${jd}
 `;
 }
 
-export function buildDeepPrompt(company, role, lang) {
+export function buildDeepPrompt(company, role, lang, opts = {}) {
+  const headless = !!opts.headless;
+  const slug = `${slugify(company)}-${role ? slugify(role) : 'general'}.md`;
+  // Manual/copy-paste path keeps Claude Code tool names. Live /api/deep must
+  // not — Gemini treats "Use WebFetch / WebSearch" as a function call and
+  // returns MALFORMED_FUNCTION_CALL with no text (HTTP 502).
+  const how = headless
+    ? `Read modes/deep.md for structure. You do NOT have access to browsing, search, or file-writing tools — write the brief from your knowledge and the inlined project context; mark uncertain or time-sensitive claims as estimates. Cover:`
+    : `Read modes/deep.md for structure. Use WebFetch / WebSearch. Cover:`;
+  const footer = headless
+    ? `Output the full markdown brief now. (The server saves it to interview-prep/${slug}.)`
+    : `Save the output to interview-prep/${slug}`;
   return `${buildLocaleDirective(lang)}You are career-ops in deep-research mode. Produce a full company brief on ${company}${role ? ` for the role of ${role}` : ''}.
 
-Read modes/deep.md for structure. Use WebFetch / WebSearch. Cover:
+${how}
   1. Company snapshot (size, funding, runway, leadership)
   2. Engineering culture (stack, blogs, GitHub, conference talks)
   3. Recent news, layoffs, acquisitions, controversies
@@ -354,7 +382,7 @@ Read modes/deep.md for structure. Use WebFetch / WebSearch. Cover:
   6. Negotiation leverage points
   7. Three smart questions for the recruiter
 
-Save the output to interview-prep/${slugify(company)}-${role ? slugify(role) : 'general'}.md
+${footer}
 `;
 }
 

--- a/server/lib/routes/llm.mjs
+++ b/server/lib/routes/llm.mjs
@@ -226,7 +226,10 @@ export function registerLlmRoutes(app) {
     const { company, role, run } = req.body || {};
     if (!company) return res.status(400).json({ error: 'company required' });
     const lang = resolveLocale(req);
-    const prompt = buildDeepPrompt(company, role, lang);
+    // Manual copy keeps Claude Code tool names (WebFetch/WebSearch). Live run
+    // must not — Gemini otherwise returns MALFORMED_FUNCTION_CALL (no tools).
+    const manualPrompt = buildDeepPrompt(company, role, lang);
+    const livePrompt = buildDeepPrompt(company, role, lang, { headless: true });
 
     // When run:true AND a key is configured, execute server-side and
     // return the rendered Markdown so the user sees real research output
@@ -235,11 +238,12 @@ export function registerLlmRoutes(app) {
     if (run) {
       let result = null;
       let mode = null;
+      const prompt = livePrompt;
       if (_provGate().wantAnthropic && hasAnthropicKey()) {
         mode = 'anthropic';
         // REVIEW-A1 — Anthropic has no filesystem; inline cv/profile/mode
         // content so "Read these files first" actually has files to read.
-        const ctx = bundleProjectContext({ modeSlugs: ['_shared', 'deep'] });
+        const ctx = bundleProjectContext({ modeSlugs: ['_shared', 'deep'], headless: true });
         const fullPrompt = ctx + prompt;
         if (fullPrompt.length > PROMPT_SIZE_SOFT_CAP) {
           return res.status(413).json({
@@ -255,7 +259,7 @@ export function registerLlmRoutes(app) {
         // (cv.md + profile.yml + modes/deep.md inlined), NOT oferta-only
         // gemini-eval.mjs. runGemini already pipes through cleanLlmMarkdown.
         mode = 'gemini';
-        const ctx = bundleProjectContext({ modeSlugs: ['_shared', 'deep'] });
+        const ctx = bundleProjectContext({ modeSlugs: ['_shared', 'deep'], headless: true });
         const fullPrompt = ctx + prompt;
         if (fullPrompt.length > PROMPT_SIZE_SOFT_CAP) {
           return res.status(413).json({
@@ -271,7 +275,7 @@ export function registerLlmRoutes(app) {
         const tp = _tailProvider();
         if (tp) {
           mode = tp.mode;
-          const ctx = bundleProjectContext({ modeSlugs: ['_shared', 'deep'] });
+          const ctx = bundleProjectContext({ modeSlugs: ['_shared', 'deep'], headless: true });
           const fullPrompt = ctx + prompt;
           if (fullPrompt.length > PROMPT_SIZE_SOFT_CAP) {
             return res.status(413).json({
@@ -298,7 +302,7 @@ export function registerLlmRoutes(app) {
 
     res.json({
       mode: 'manual',
-      prompt,
+      prompt: manualPrompt,
       message: (hasAnthropicKey() || hasGeminiKey() || hasOpenAIKey() || hasQwenKey() || hasOpenRouterKey() || hasGitHubModelsKey())
         ? 'Set { run: true } to execute via Anthropic/Gemini/OpenAI/Qwen/OpenRouter/GitHub Models, or copy the prompt into Claude Code.'
         : 'No API key set. Paste this into Claude Code for full deep research with WebFetch.',

--- a/tests/critical-fixes.test.mjs
+++ b/tests/critical-fixes.test.mjs
@@ -21,7 +21,7 @@ import { isPrivateOrLoopbackHost } from '../server/lib/security.mjs';
 // escaped the temp root). Load the prompt builders DYNAMICALLY, inside before(),
 // after the env is set, so paths.mjs resolves to the temp dir. `security.mjs`
 // does not import paths.mjs, so it stays a static import.
-let buildLocaleDirective, resolveLocale, buildEvaluationPrompt, buildDeepPrompt, buildModePrompt;
+let buildLocaleDirective, resolveLocale, buildEvaluationPrompt, buildDeepPrompt, buildModePrompt, bundleProjectContext;
 
 let server;
 let baseUrl;
@@ -37,10 +37,12 @@ before(async () => {
   writeFileSync(resolve(dir, 'data', 'applications.md'), '');
   writeFileSync(resolve(dir, 'data', 'pipeline.md'), '# pipeline\n');
   writeFileSync(resolve(dir, 'modes', 'oferta.md'), 'oferta\n');
+  writeFileSync(resolve(dir, 'modes', '_shared.md'), '# shared\nUse WebSearch for comp.\n| WebFetch | fallback |\n');
+  writeFileSync(resolve(dir, 'modes', 'deep.md'), '# deep\nstructure\n');
   process.env.CAREER_OPS_ROOT = dir;
 
   // Import paths.mjs-backed modules ONLY after CAREER_OPS_ROOT is set.
-  ({ buildLocaleDirective, resolveLocale, buildEvaluationPrompt, buildDeepPrompt, buildModePrompt } =
+  ({ buildLocaleDirective, resolveLocale, buildEvaluationPrompt, buildDeepPrompt, buildModePrompt, bundleProjectContext } =
     await import('../server/lib/prompts.mjs'));
   const { createApp } = await import('../server/index.mjs');
   const app = createApp();
@@ -196,6 +198,27 @@ test('PR-2: buildDeepPrompt embeds the locale directive', () => {
   const p = buildDeepPrompt('Anthropic', 'Backend', 'ja');
   assert.match(p, /Respond in Japanese/);
 });
+
+// Headless /api/deep (Gemini generateContent) has no tools. Instructing
+// WebFetch/WebSearch causes finishReason MALFORMED_FUNCTION_CALL → HTTP 502.
+test('headless buildDeepPrompt must not name Claude Code tools', () => {
+  const manual = buildDeepPrompt('Live Nation Entertainment', '', 'en');
+  assert.match(manual, /WebFetch|WebSearch/);
+  assert.match(manual, /Save the output to interview-prep\//);
+
+  const live = buildDeepPrompt('Live Nation Entertainment', '', 'en', { headless: true });
+  assert.doesNotMatch(live, /WebFetch|WebSearch/);
+  assert.doesNotMatch(live, /Save the output to interview-prep\//);
+  assert.match(live, /Live Nation Entertainment/);
+  assert.match(live, /no (browsing|tool)|do NOT have access|without tools|training data|knowledge/i);
+});
+
+test('headless bundleProjectContext overrides inlined tool tables', () => {
+  const ctx = bundleProjectContext({ modeSlugs: ['_shared', 'deep'], headless: true });
+  assert.match(ctx, /WebSearch/); // still inlined from modes/_shared.md
+  assert.match(ctx, /do NOT have access|headless API session/i);
+});
+
 
 test('PR-2: buildModePrompt embeds locale + strips lang/locale from rendered context', () => {
   const tmpl = 'mode template body';


### PR DESCRIPTION
Live /api/deep told Gemini to Use WebFetch/WebSearch with no tools → MALFORMED_FUNCTION_CALL → HTTP 502. Add headless buildDeepPrompt + bundleProjectContext override; keep manual prompt with Claude Code tools. Tests included.

Made with [Cursor](https://cursor.com)