### PR TITLE
docs(canonical): sync career-ops-canonical CLI roster (v1.126.0 follow-up)

### DIFF
--- a/docs/career-ops-canonical.md
+++ b/docs/career-ops-canonical.md
@@ -4,7 +4,7 @@
 
 ## 1. What career-ops is
 
-An open-source job-search system that runs as commands inside an AI coding CLI (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot CLI). Model-agnostic. The CLI evaluates each posting against your CV using a structured rubric, generates tailored PDF resumes, and tracks every application locally.
+An open-source job-search system that runs as commands inside an AI coding CLI (Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen Code, Kimi, GitHub Copilot CLI — plus Gemini CLI as a legacy wrapper). Model-agnostic. The CLI evaluates each posting against your CV using a structured rubric, generates tailored PDF resumes, and tracks every application locally.
 
 ### Problem it solves
 
@@ -131,7 +131,7 @@ Alternative MCP registration via `.claude/settings.local.json`:
 
 | | career-ops (CLI) | career-ops-ui (this repo) |
 |---|---|---|
-| **Where it runs** | Inside Claude Code / Codex / Cursor / Gemini CLI | `http://127.0.0.1:4317` in your browser |
+| **Where it runs** | Inside Claude Code / Codex / OpenCode / Antigravity CLI / Grok Build CLI / Qwen Code / Kimi / GitHub Copilot CLI (Gemini CLI legacy) | `http://127.0.0.1:4317` in your browser |
 | **Primary surface** | `/career-ops <mode>` slash commands | Sidebar with one page per workflow |
 | **Form fill** | Yes, via Playwright MCP | No — generates the checklist; submission stays in the CLI |
 | **PDF generation** | `generate-pdf.mjs <input.html> <output.pdf>` | `📄 Generate PDF` button on `#/cv`, `#/reports/:slug`, `#/evaluate`, `#/deep`, `#/interview-prep` |


### PR DESCRIPTION
Verification follow-up to #156. `docs/career-ops-canonical.md` still carried the pre-v1.28 stale CLI set — `Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot CLI` — with **Cursor** (banned in help/README by the canonical-docs gate, but that gate never covered this file) and missing OpenCode/Antigravity/Grok Build/Qwen/Kimi.

Both the intro line and the comparison-table "Where it runs" row now match the parent's `docs/SUPPORTED_CLIS.md`: Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen Code, Kimi, GitHub Copilot CLI + Gemini CLI (legacy). Docs-only, no code/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)