### PR TITLE
chore(tests): remove dead loadScanSrc-migration imports (close 5 CodeQL alerts)

### DIFF
--- a/tests/scan-advanced-disclosure.test.mjs
+++ b/tests/scan-advanced-disclosure.test.mjs
@@ -13,9 +13,8 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 import { loadAppCss } from './helpers/css.mjs';
 import { loadScanSrc } from './helpers/scan-src.mjs';
 

--- a/tests/scan-i18n-gaps.test.mjs
+++ b/tests/scan-i18n-gaps.test.mjs
@@ -7,13 +7,9 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
 import { loadAssembledDict } from './helpers/i18n-vm.mjs';
 import { loadScanSrc } from './helpers/scan-src.mjs';
 
-const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const scan = loadScanSrc();
 
 test('scan.js routes the summary/badge strings through t()', () => {

--- a/tests/scan-seniority-facet-v1129.test.mjs
+++ b/tests/scan-seniority-facet-v1129.test.mjs
@@ -6,14 +6,8 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
 import { I18N_LANGS, localeSource } from './helpers/i18n-vm.mjs';
 import { loadScanSrc } from './helpers/scan-src.mjs';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const read = (...p) => readFileSync(resolve(__dirname, '..', ...p), 'utf8');
 
 test('scan.js wires a seniority filter via JobFacets into filtering + state', () => {
   const src = loadScanSrc();


### PR DESCRIPTION
Removes the dead `readFileSync` / `resolve` / `ROOT` / `read` scaffolding left in three scan source-static tests after the v1.132.0 `loadScanSrc()` repointing (same class cleaned from the CSS tests then, missed for these). Closes CodeQL code-scanning alerts **#412–#416** (`js/unused-local-variable`). Test-only, no behaviour change; the three suites stay green (14/14).

Separately, the two HIGH `js/missing-rate-limiting` alerts (#417/#418) on the new v1.133.0 relays were **dismissed as false positives** — both routes carry the project's custom `llmRateLimit` middleware, which CodeQL doesn't credit (same documented FP class as the sibling `/api/stats/*` relays and v1.106.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)