### PR TITLE
docs(workable): document intentional empty company + scanner backfill

### DIFF
--- a/server/lib/sources/workable.mjs
+++ b/server/lib/sources/workable.mjs
@@ -183,6 +183,12 @@ function normalize(j, url) {
   return {
     id: `wk-${j.shortcode || j.id}`,
     title: (j.title || '').trim(),
+    // The widget payload carries the account name at the TOP level
+    // (`payload.name`), not per-job, so this is normally '' — deliberately left
+    // for the scanner to backfill from the tracked entry's `c.name`
+    // (en-scanner stamps `company: i.company || c.name`), identical to the
+    // Ashby/Lever contract. `c.name` is the user's canonical portals.yml name,
+    // a cleaner display value than the raw ATS account name would be.
     company: j.company || j.account?.name || '',
     url,
     salary: '',


### PR DESCRIPTION
## Summary

Comment-only follow-up to the v1.134.0 Workable widget rewrite. A code review re-flagged `company: j.company || j.account?.name || ''` in `normalize()` as potentially leaving every widget job with an empty company.

**It's intentional and correct** — verified against the code:
- The widget payload carries the account name at the **top level** (`payload.name`), not per-job, so `normalize()` returns `company: ''`.
- The scanner backfills it universally at `en-scanner.mjs:171` — `company: i.company || c.name` — to the tracked entry's `c.name`, the **same contract Ashby/Lever** use.
- `c.name` (the user's canonical `portals.yml` name) is a cleaner display value than the raw ATS account name, so threading `payload.name` would be a slight *regression* in display quality.
- The test already documented this (`sources-workable.test.mjs:102`).

This PR just mirrors that note at the source so `normalize()` isn't re-flagged when read in isolation — the reviewer's own suggested low-cost resolution ("worth a one-line comment").

## Verification
- **Comment-only**, 6 insertions, no behavior change. `git diff` is additive comment lines only.
- Workable suite **13/13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)