### PR TITLE
fix(test): drop unused variable flagged by CodeQL (remotli dedup test)

### DIFF
--- a/tests/sources-remotli.test.mjs
+++ b/tests/sources-remotli.test.mjs
@@ -244,8 +244,7 @@ test('fetchRemotli: walks pages, aggregates all rows, stops after the short page
 });
 
 test('fetchRemotli: dedupes rows repeated by url across pages', async () => {
-  const fetchImpl = async (url) => {
-    const page = Number(new URL(url).searchParams.get('page'));
+  const fetchImpl = async () => {
     // Every page returns the SAME 50 rows → after dedup only 50 survive.
     return jsonResponse({ jobs: Array.from({ length: 50 }, (_, i) => mk(i)), pagination: { totalPages: 3 } });
   };


### PR DESCRIPTION
Closes the only open **code-scanning** alert — `js/unused-local-variable` (note) in `tests/sources-remotli.test.mjs`.

The dedup test's `fetchImpl` computed `const page = Number(new URL(url).searchParams.get('page'))` but returns the same 50 rows on every page, so `page` was never read. Removed it (the fn no longer needs `url`). The other three `page` reads in the file are genuinely used.

**Verification:** `node --test tests/sources-remotli.test.mjs` → **22/22**. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)