### PR TITLE
docs(qa): actualize the 3 perennial prompts to v1.157.0

### DIFF
--- a/qa/DESIGNER-EXPORT-PROMPT.md
+++ b/qa/DESIGNER-EXPORT-PROMPT.md
@@ -8,11 +8,13 @@
 >
 > Output **one** file: `qa/reports/<YYYY-MM-DD>-DESIGN-EXPORT.md`.
 >
-> Current baseline **v1.152.0** (32 route modules · 79 scan sources =
-> 74 EN + 5 RU · 17 locales · **7 headless LLM providers** auto-ordered
-> Anthropic → Gemini → OpenAI → Qwen → OpenRouter → GitHub Models →
-> Hermes). The UX roadmap **`docs/UX-ROADMAP.md`** (Phases 1–5) is fully
-> shipped — treat any residual Phase items as done, not findings.
+> Current baseline **v1.157.0** (32 route modules · 79 scan sources =
+> 74 EN + 5 RU · 17 locales · help 31 H2 / 112 H3 · **7 headless LLM
+> providers** auto-ordered Anthropic → Gemini → OpenAI → Qwen → OpenRouter →
+> GitHub Models → Hermes — a keyless forced `LLM_PROVIDER` falls back to any
+> configured provider (v1.157.0), so live evals run on ANY key). The UX
+> roadmap **`docs/UX-ROADMAP.md`** (Phases 1–5) is fully shipped — treat any
+> residual Phase items as done, not findings.
 > Dark-mode contrast is guarded from v1.137.0 (theme-aware alias tokens —
 > see Part 1 §1).
 >

--- a/qa/FUNCTIONALITY-CHECK.md
+++ b/qa/FUNCTIONALITY-CHECK.md
@@ -64,8 +64,12 @@ dedicated 404 view, not silently fall back to dashboard).
 ## §2 — The core journey actually completes (Scenario A, cold start)
 
 Empty parent files; set up exactly ONE provider key. Repeat the whole
-arc once per provider (**Anthropic, Gemini, OpenAI, Qwen** — the "OR"
-promise):
+arc once per provider (**Anthropic, Gemini, OpenAI, Qwen, OpenRouter,
+GitHub Models, Hermes** — all seven; the "OR" promise). **v1.157.0:** even
+with a stale `LLM_PROVIDER=claude` pin (as `init` writes), setting only a
+non-Anthropic key (e.g. `OPENROUTER_API_KEY`) MUST still run live — a keyless
+forced provider falls back to any configured one, so `#/deep` shows ⚡ Run
+live and `#/dashboard` shows **Live evals · ready**:
 
 1. Land on `#/dashboard` with **0 keys** → the red onboarding banner
    states ⚡ Run-live is manual-prompt mode and links to

--- a/qa/UX-AUDIT-PROMPT.md
+++ b/qa/UX-AUDIT-PROMPT.md
@@ -1,11 +1,16 @@
 # SENIOR UX-DESIGNER AUDIT — career-ops-ui
 
-> **Baseline: v1.152.0** (32 route modules · 30 views · **17 locales** ·
-> help bundles 30 H2 / 108 H3 · **79 scanner sources = 74 EN + 5 RU** ·
+> **Baseline: v1.157.0** (32 route modules · 30 views · **17 locales** ·
+> help bundles **31 H2 / 112 H3** — §31 "Running the whole stack in the cloud"
+> added v1.154.0 · **79 scanner sources = 74 EN + 5 RU** ·
 > **7 headless LLM providers**: Anthropic → Gemini → OpenAI → Qwen →
-> OpenRouter → GitHub Models → Hermes, auto-ordered).
+> OpenRouter → GitHub Models → Hermes, auto-ordered — and as of v1.157.0 a
+> forced `LLM_PROVIDER` with no key falls back to any configured provider, so
+> live evals run on ANY key, not just Anthropic/Gemini).
 > The UX roadmap **`docs/UX-ROADMAP.md`** (Phases 1–5) is fully shipped;
 > treat any residual Phase items as done, not findings.
+> The oversized views were split under the 800-line limit (config.js P-15,
+> scan.js P-16, v1.155–v1.156) — a pure refactor, no UX change.
 > Dark-mode contrast is guarded from v1.137.0 (theme-aware alias tokens;
 > 0 WCAG-AA text failures across all views) — judge the dark theme against
 > that baseline, not as broken.


### PR DESCRIPTION
UX-AUDIT + DESIGNER-EXPORT baselines → v1.157.0; FUNCTIONALITY-CHECK §2 → all 7 providers + the keyless-pin-fallback check. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)