### PR TITLE
test(css): drop identity self-replace in design-tokens-scale test (CodeQL #431)

### DIFF
--- a/tests/design-tokens-scale.test.mjs
+++ b/tests/design-tokens-scale.test.mjs
@@ -22,7 +22,7 @@ const APP = FILES[0];
 
 test('D-4: the --font-size-* ramp and --z-* layers are defined on :root', () => {
   for (const t of ['xs', 'sm', 'md', 'base', 'lg', 'xl', '2xl']) {
-    assert.match(APP, new RegExp(`--font-size-${t.replace('2xl', '2xl')}:\\s*\\d`), `--font-size-${t} defined`);
+    assert.match(APP, new RegExp(`--font-size-${t}:\\s*\\d`), `--font-size-${t} defined`);
   }
   for (const t of ['topbar', 'sidebar', 'hud', 'banner', 'modal', 'popover', 'toast', 'fab', 'drawer', 'skiplink']) {
     assert.match(APP, new RegExp(`--z-${t}:\\s*\\d`), `--z-${t} defined`);


### PR DESCRIPTION
Resolves **CodeQL #431** (`js/identity-replacement`, medium) — [alert](https://github.com/Fighter90/career-ops-ui/security/code-scanning/431).

`tests/design-tokens-scale.test.mjs:25` had `t.replace('2xl', '2xl')` — a no-op self-replacement left over from writing the D-4 token canary (`t` is already the exact token suffix). Removed it.

Test-only, no product change (no version bump / CHANGELOG); the canary still passes 3/3. The alert auto-resolves on the next CodeQL scan of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)