### PR TITLE
feat(site): add the Product Hunt badge to the cvstart.org hero

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -43,6 +43,9 @@ const adaptersRounded = Math.floor(facts.adapters / 5) * 5; // honest "~55"
           </a>
           <p class="text-sm text-ink-soft">{t(locale, 'hero.fineprint')}</p>
         </div>
+        <div class="mt-6">
+          <a href="https://www.producthunt.com/products/career-ops-ui?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-career-ops-ui" target="_blank" rel="noopener noreferrer"><img alt="career-ops-ui - The open-source job search command center | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1221619&amp;theme=light&amp;t=1786616490465" /></a>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
As requested — add the Product Hunt badge to **cvstart.org**.

Placed the Product Hunt "featured" badge in the **Hero CTA area** (under the install tabs + GitHub button). The Hero is a shared component, so this one insertion renders on **all 17 localized landing pages**. The site has no CSP, so the `api.producthunt.com` badge image loads.

Verified: `npm run build` clean (86 pages), badge present in `dist/index.html` and the localized pages (e.g. `/ru/`).

Site-only marketing change — no app/code/version change. Pages redeploys on merge (`site/**` paths-filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)