### PR TITLE
chore(comments): reword code comments to stand alone (drop cross-project provenance)

### DIFF
--- a/.claude/PROJECT-CONTEXT.md
+++ b/.claude/PROJECT-CONTEXT.md
@@ -194,6 +194,25 @@ For trivial work (single file, single concern, < 30 min): just edit, run tests, 
 - **New runtime dep** — current production deps are `express`, `js-yaml`, `multer`. Adding more needs a spec.
 - **Real LLM calls in tests** — mock the SDK adapter; never hit Anthropic / Gemini from a unit test.
 
+## Upstream mirror inventory (parent-sync map)
+
+Some `server/lib` modules are **hand-mirrors of parent `career-ops` modules** and must be re-checked whenever the parent changes them. The in-code "ported from"/"parity" comments were removed for product cleanliness, so this is the authoritative map (keep it here, not in the source):
+
+| web-ui file | tracks parent |
+|---|---|
+| `server/lib/role-matcher.mjs` | `role-matcher.mjs` (web-ui is AHEAD — Unicode `\p{L}` strip) |
+| `server/lib/detect-reposts.mjs` | `detect-reposts.mjs` |
+| `server/lib/html-entities.mjs` | `providers/_html-entities.mjs` |
+| `server/lib/http-json.mjs` | `providers/_http.mjs` |
+| `server/lib/trust-validator.mjs` | `providers/_trust-validator.mjs` |
+| `server/lib/states.mjs` | states / `templates/states.yml` (+ web/ states) |
+| `server/lib/location-filter.mjs`, `scan-sanitize.mjs`, `cooldown.mjs`, `text-key.mjs` | corresponding `scan.mjs` filter/sanitize logic |
+| `server/lib/sources/*.mjs` | `providers/*.mjs` (each job board) |
+| `server/lib/portals/adapters/*.mjs` | provider detection in `providers/*.mjs` |
+| `public/js/lib/{logbuf,bug-report,job-facets,score-tone,company-logo,tracker-stages}.js` | parent `web/src/lib/*` |
+
+When porting a parent change here, frame CHANGELOG/README as a **new feature** (never "ported/parity"); provenance stays only in the commit body + this file. See [`memory`](../../.claude) note *changelog-readme-new-feature-framing*.
+
 ## Realizations / hard-won notes (v1.57–v1.97)
 
 - **I18N-SPLIT (v1.60.0) — per-locale dictionary.** Translations live ONLY in `public/js/lib/locales/i18n-dict.<lang>.js` (12 files) + `i18n-dict.aliases.js`; `i18n-dict.js` is an assembler that rebuilds `window.__I18N_DICT` — it stores nothing. Three traps: (1) **vm-realm deepEqual** — objects assembled inside `node:vm` have a foreign `Object.prototype`, so `deepStrictEqual` vs a JSON snapshot throws "same structure but not reference-equal"; round-trip `JSON.parse(JSON.stringify(x))` first. (2) **Load order is load-bearing** — all 13 locale `<script>`s must precede `i18n-dict.js`, which must precede `i18n.js` (locked by `tests/i18n-locale-files.test.mjs`). (3) **A "passing" CI step can be a no-op** — the `ci.yml` inline i18n check validated an *empty* dict for ~37 releases after the v1.23 split (it loaded only `i18n.js`); now it loads the full chain + a `keys < 600` floor. Node tests load the dict via `tests/helpers/i18n-vm.mjs` (`loadAssembledDict` / `loadI18n` / `legacyDictText` / `allLocaleSource`).

--- a/.claude/PROJECT-CONTEXT.md
+++ b/.claude/PROJECT-CONTEXT.md
@@ -211,7 +211,7 @@ Some `server/lib` modules are **hand-mirrors of parent `career-ops` modules** an
 | `server/lib/portals/adapters/*.mjs` | provider detection in `providers/*.mjs` |
 | `public/js/lib/{logbuf,bug-report,job-facets,score-tone,company-logo,tracker-stages}.js` | parent `web/src/lib/*` |
 
-When porting a parent change here, frame CHANGELOG/README as a **new feature** (never "ported/parity"); provenance stays only in the commit body + this file. See [`memory`](../../.claude) note *changelog-readme-new-feature-framing*.
+When porting a parent change here, frame CHANGELOG/README as a **new feature** (never "ported/parity"); provenance stays only in the commit body + this file. See the memory note *changelog-readme-new-feature-framing* (centralized here on purpose — the map is engineering context, kept out of product/CHANGELOG surfaces, not concealed).
 
 ## Realizations / hard-won notes (v1.57–v1.97)
 

--- a/public/js/lib/bug-report.js
+++ b/public/js/lib/bug-report.js
@@ -1,8 +1,6 @@
 /* global window, document, navigator, location, fetch, UI, I18n */
 /**
- * bug-report.js — in-app bug reporter. Ported from parent career-ops
- * `web/src/lib/report/report.ts` (web-v0.2.0) into the web-ui contract
- * (vanilla JS, no framework). Gathers a STRUCTURAL diagnostic snapshot
+ * bug-report.js — in-app bug reporter (vanilla JS, no framework). Gathers a STRUCTURAL diagnostic snapshot
  * (versions, route, browser, viewport, recent errors from logbuf.js, a
  * fail-check data-shape), computes a deterministic dedupe fingerprint, and
  * opens a PRE-FILLED GitHub issue — preview-then-confirm, nothing auto-filed.

--- a/public/js/lib/company-logo.js
+++ b/public/js/lib/company-logo.js
@@ -20,7 +20,7 @@ window.CompanyLogo = (function () {
   var PREF_KEY = 'coShowLogos';
 
   // Curated company NAME → domain overrides for the common cases slug+.com gets
-  // wrong (brand ≠ registrable slug). Ported from the parent web/src/lib/company.ts.
+  // wrong (brand ≠ registrable slug).
   var DOMAIN_OVERRIDES = {
     anthropic: 'anthropic.com',
     openai: 'openai.com',
@@ -153,7 +153,7 @@ window.CompanyLogo = (function () {
   /**
    * Resolve a likely registrable domain from the company NAME alone, or null if
    * the input is empty/unusable. Curated overrides first (raw then suffix-
-   * stripped), then a slug+.com heuristic. Ported from parent companyDomain().
+   * stripped), then a slug+.com heuristic.
    */
   function domainFromName(name) {
     if (!name || typeof name !== 'string') return null;

--- a/public/js/lib/job-facets.js
+++ b/public/js/lib/job-facets.js
@@ -1,7 +1,6 @@
 /* global window */
 /**
- * job-facets.js — zero-token job "facet" derivations (ported from the parent
- * career-ops web app's inbox helpers, `web/src/lib/inbox.ts`).
+ * job-facets.js — zero-token job "facet" derivations.
  *
  * window.JobFacets exposes three PURE, client-side functions. Every signal is
  * FREE — parsed from data a raw posting already carries (URL host, title text,

--- a/public/js/lib/logbuf.js
+++ b/public/js/lib/logbuf.js
@@ -2,8 +2,7 @@
 /**
  * logbuf.js — a tiny client-side ring buffer of recent ERRORS (not arbitrary
  * logs → far less PII surface) that feeds the in-app bug reporter
- * (`bug-report.js`). Ported from parent career-ops `web/src/lib/report/logbuf.ts`
- * (web-v0.2.0). Installed once, as early as possible, so it captures failures
+ * (`bug-report.js`). Installed once, as early as possible, so it captures failures
  * from the first paint.
  *
  * Captures: console.error, window 'error', 'unhandledrejection', and FAILED

--- a/public/js/lib/scan-results.js
+++ b/public/js/lib/scan-results.js
@@ -250,7 +250,7 @@ window.ScanResults = (function () {
       // server-side scanner matched a `seniority_boost` keyword on the
       // title. Title attribute reveals WHICH keyword matched, so the
       // user can trace it back to portals.yml.
-      // v1.76.0 — trust badge (parent career-ops v1.13.0). Only shown when
+      // v1.76.0 — trust badge. Only shown when
       // trust_filter is enabled AND the posting is below "high" trust. The badge
       // is language-neutral (⚠ + score/100); the tooltip lists the flag codes,
       // so it renders identically across all 12 locales with no i18n keys.

--- a/public/js/lib/score-tone.js
+++ b/public/js/lib/score-tone.js
@@ -1,7 +1,7 @@
 /**
- * score-tone.js — shared fit-score → tone mapping (parent web/ port #3, v1.128.0).
+ * score-tone.js — shared fit-score → tone mapping (v1.128.0).
  *
- * Ports the parent career-ops web app's `format.ts` scoreTone: a four-tier
+ * A four-tier
  * threshold (>=4.2 good / >=3.8 warn / >=3.0 muted / <3.0 bad) with a
  * letter-grade fallback (A/B/C/…), replacing our coarse ">=4 high / >=3 mid /
  * else low" split that mis-colored NaN and letter grades. Pure, CSP-safe.

--- a/public/js/lib/score-tone.js
+++ b/public/js/lib/score-tone.js
@@ -1,8 +1,7 @@
 /**
  * score-tone.js — shared fit-score → tone mapping (v1.128.0).
  *
- * A four-tier
- * threshold (>=4.2 good / >=3.8 warn / >=3.0 muted / <3.0 bad) with a
+ * A four-tier threshold (>=4.2 good / >=3.8 warn / >=3.0 muted / <3.0 bad) with a
  * letter-grade fallback (A/B/C/…), replacing our coarse ">=4 high / >=3 mid /
  * else low" split that mis-colored NaN and letter grades. Pure, CSP-safe.
  *

--- a/public/js/lib/tracker-stages.js
+++ b/public/js/lib/tracker-stages.js
@@ -1,5 +1,5 @@
 /* window.TrackerStages — pure helpers for the #/tracker CRM stage-tab board
- * (v1.131.0, ported from the parent web/ `/pipeline` view).
+ * (v1.131.0).
  *
  * The canonical funnel (stage labels in order) and the alias-fold map both come
  * from the server (GET /api/tracker/stages → server/lib/states.mjs, which reads

--- a/public/js/views/batch.js
+++ b/public/js/views/batch.js
@@ -94,7 +94,7 @@ Router.register('batch', async () => {
     maxRetriesIn.disabled = !retry.checked;
     if (!retry.checked) maxRetriesIn.value = '';
   });
-  // v1.31.0 — parent career-ops 1.8.0 added batch-runner.sh --model
+  // v1.31.0 — batch-runner.sh gained a --model
   // (#504) + --start-from. Surface both for parity (same defensive
   // server-side validation as --max-retries).
   const modelIn = c('input', {

--- a/public/js/views/cv-studio.js
+++ b/public/js/views/cv-studio.js
@@ -173,7 +173,7 @@ Router.register('cv-studio', async () => {
     jdIn, headIn, c('div', { style: { marginTop: '8px' } }, tailorBtn), tailorOut,
   ]));
 
-  // ── 5. Add to CV (v1.117.0, parent parity — modes/add.md generalized) ──
+  // ── 5. Add to CV (v1.117.0) ──
   // A project/publication URL or pasted text → grounded ATS bullets to review
   // and paste into the CV editor yourself. Suggestions only — nothing is
   // written to any file (the URL fetch is SSRF-guarded server-side).

--- a/public/js/views/funded.js
+++ b/public/js/views/funded.js
@@ -1,6 +1,6 @@
 /* global Router, API, UI, I18n, HelpHint */
 /**
- * #/funded — Funded-company discovery (v1.133.0, parent parity #2117).
+ * #/funded — Funded-company discovery (v1.133.0).
  *
  * Read-only view over GET /api/company-funded, which shells out to the parent's
  * company-funded.mjs (review-first discovery from public, host-pinned RSS/JSON

--- a/public/js/views/interview-digest.js
+++ b/public/js/views/interview-digest.js
@@ -1,6 +1,6 @@
 /* global Router, API, UI, I18n, HelpHint */
 /**
- * #/interview-digest — Weekly interview digest (v1.133.0, parent parity #2129/#2130).
+ * #/interview-digest — Weekly interview digest (v1.133.0).
  *
  * Read-only view over GET /api/interview/weekly-digest, which shells out to the
  * parent's zero-LLM weekly-digest.mjs — a mechanical roll-up of

--- a/public/js/views/mode-page.js
+++ b/public/js/views/mode-page.js
@@ -380,7 +380,7 @@
         ])
       : null;
 
-    // v1.117.0 (parent parity) — the followup mode page gains a deterministic
+    // v1.117.0 — the followup mode page gains a deterministic
     // CADENCE BOARD above the LLM form: GET /api/followup shells out to the
     // parent's followup-cadence.mjs and reports per-application urgency
     // (urgent / overdue / waiting / cold). Fail-soft: without the parent

--- a/public/js/views/scan.js
+++ b/public/js/views/scan.js
@@ -316,7 +316,7 @@ Router.register('scan', async () => {
   const field = (labelText, el) => c('label', { className: 'field scan-field' }, [c('span', { className: 'scan-field__label' }, labelText), el]);
 
 
-  // v1.83.0 — repost / ghost-posting detector (parent career-ops v1.15.0).
+  // v1.83.0 — repost / ghost-posting detector.
   // A collapsed panel that lazy-loads GET /api/scan/reposts on first open:
   // company+role clusters re-listed under different URLs within a window =
   // likely stale / ghost postings. CSP-safe (addEventListener, no innerHTML).

--- a/public/js/views/stats.js
+++ b/public/js/views/stats.js
@@ -132,7 +132,7 @@ Router.register('stats', async () => {
     { id: 'market', label: t('stats.tabMarket', 'Market report'), hint: 'stats.hint.market', render: renderMarket },
     { id: 'pipeline', label: t('stats.tabPipeline', 'My pipeline'), hint: 'stats.hint.pipeline', render: renderPipeline },
     { id: 'trend', label: t('stats.tabTrend', 'Target-role trend'), hint: 'stats.hint.trend', render: renderTrend },
-    // v1.117.0 (parent parity) — rejection patterns + per-ATS-vendor advance
+    // v1.117.0 — rejection patterns + per-ATS-vendor advance
     // rate from the parent's analyze-patterns.mjs (read-only shell-out).
     { id: 'patterns', label: t('stats.tabPatterns', 'Rejection patterns'), hint: 'stats.hint.patterns', render: renderPatterns },
     // v1.118.0 (parent v1.18.0 parity) — lifetime pipeline stats (stats.mjs
@@ -298,7 +298,7 @@ Router.register('stats', async () => {
 
     // Conversion rates — how far applications progress down the funnel.
     // v1.118.0 — 'Hired' (offer accepted) counts as having advanced through
-    // every earlier funnel stage, mirroring the parent's canonical order.
+    // every earlier funnel stage, mirroring the canonical funnel order.
     const advanced = (...statuses) => rows.filter((r) => statuses.includes((r.status || '').trim())).length;
     const applied = advanced('Applied', 'Responded', 'Interview', 'Offer', 'Hired');
     const responded = advanced('Responded', 'Interview', 'Offer', 'Hired');
@@ -541,7 +541,7 @@ Router.register('stats', async () => {
     return wrap;
   }
 
-  // ── tab 4: rejection patterns / ATS channels (v1.117.0, parent parity) ─────
+  // ── tab 4: rejection patterns / ATS channels (v1.117.0) ─────
   // GET /api/stats/patterns shells out to the parent's analyze-patterns.mjs
   // (read-only). Renders outcome mix, actionable recommendations, and the
   // per-ATS-vendor advance rate; honest empty state when the script is absent.
@@ -599,7 +599,7 @@ Router.register('stats', async () => {
     return wrap;
   }
 
-  // ── tab 5: lifetime pipeline stats + salary gap (v1.118.0, parent parity) ──
+  // ── tab 5: lifetime pipeline stats + salary gap (v1.118.0) ──
   // GET /api/stats/lifetime relays the parent's stats.mjs (tracker roll-up,
   // cumulative funnel, lifetime scanner totals, portal coverage); GET
   // /api/stats/salary-gap relays salary-gap.mjs (desired vs advertised vs

--- a/public/js/views/tracker.js
+++ b/public/js/views/tracker.js
@@ -2,7 +2,7 @@
 Router.register('tracker', async () => {
   const c = UI.el;
   const t = (k, f) => I18n.t(k, f);
-  // v1.131.0 — CRM stage-tab board (parent web/ `/pipeline` port). Rows +
+  // v1.131.0 — CRM stage-tab board. Rows +
   // the canonical funnel are fetched together; the stages endpoint fails soft
   // to an empty funnel (the board degrades to an ALL-only view) so the tracker
   // still renders if the parent's states.yml is momentarily unreadable.
@@ -177,7 +177,7 @@ Router.register('tracker', async () => {
     el.addEventListener('input', () => { pager.reset(); applyFilters(); })
   );
   function row(r) {
-    // v1.128.0 (parent web/ port #3) — finer 4-tier tone (>=4.2/3.8/3.0) with a
+    // v1.128.0 — finer 4-tier tone (>=4.2/3.8/3.0) with a
     // letter-grade fallback, via the shared ScoreTone helper. Falls back to the
     // old coarse split only if the helper script somehow didn't load.
     const scoreCls = (window.ScoreTone && window.ScoreTone.scoreClass)

--- a/server/lib/anthropic.mjs
+++ b/server/lib/anthropic.mjs
@@ -8,7 +8,7 @@
  * override via ANTHROPIC_MODEL env var.
  *
  * v1.54.9 — key/model lookups go through effectiveEnv() so a key set
- * in the parent `.env` after boot is honoured without a server
+ * in the `.env` after boot is honoured without a server
  * restart, and key DETECTION (hasAnthropicKey) stays consistent with
  * the key the request actually SENDS. This removes the asymmetry that
  * routed evaluations to a stale/invalid Gemini key when Anthropic was
@@ -76,7 +76,7 @@ export async function runAnthropic(prompt, opts = {}) {
 
 /**
  * "Is the Anthropic key set?" — effective view: live process.env OR
- * the parent `.env` file. v1.54.9: previously process.env-only, which
+ * the `.env` file. v1.54.9: previously process.env-only, which
  * went stale when the key was added after boot and mis-routed
  * evaluations to Gemini.
  */
@@ -86,8 +86,8 @@ export function hasAnthropicKey() {
 
 /**
  * "Is the Gemini key set?" — same effective view as hasAnthropicKey
- * so the two never drift (REVIEW-B2). The Gemini exec path is a parent
- * Node subprocess that already reads the parent `.env`, so detecting
+ * so the two never drift (REVIEW-B2). The Gemini exec path is a
+ * Node subprocess that already reads the `.env`, so detecting
  * the key the same way keeps routing decisions consistent with what
  * actually runs.
  */

--- a/server/lib/cooldown.mjs
+++ b/server/lib/cooldown.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * cooldown.mjs — re-apply cooldown filter (parent career-ops v1.15.0, #1201).
+ * cooldown.mjs — re-apply cooldown filter.
  *
  * Skips scanned jobs at companies you applied to recently, so the scan stays
  * focused on NEW opportunities instead of re-surfacing roles you already chased.
@@ -32,7 +32,7 @@ export function addDays(dateStr, days) {
 }
 
 /**
- * Normalized company match (parent #1201): exact match on alphanumerics-only,
+ * Normalized company match: exact match on alphanumerics-only,
  * else a word-boundary match on the space-normalized forms. So "Acme Inc"
  * matches "Acme, Inc." and "Acme" matches "Acme Corp".
  */

--- a/server/lib/detect-reposts.mjs
+++ b/server/lib/detect-reposts.mjs
@@ -2,8 +2,7 @@
 /**
  * detect-reposts.mjs — repost / ghost-posting detector.
  *
- * Operates on the web-ui scan-history.tsv format. Groups scan-history rows by
- * company,
+ * Operates on the web-ui scan-history.tsv format. Groups scan-history rows by company,
  * fuzzy-matches role titles via roleFuzzyMatch, and flags any company+role that
  * appears 2+ times with DIFFERENT URLs inside a rolling window (default 90d).
  * Such clusters are almost certainly the same opening being re-listed by the

--- a/server/lib/detect-reposts.mjs
+++ b/server/lib/detect-reposts.mjs
@@ -2,8 +2,8 @@
 /**
  * detect-reposts.mjs — repost / ghost-posting detector.
  *
- * Ported from parent career-ops `detect-reposts.mjs` (v1.15.0) and adapted to
- * the web-ui scan-history.tsv format. Groups scan-history rows by company,
+ * Operates on the web-ui scan-history.tsv format. Groups scan-history rows by
+ * company,
  * fuzzy-matches role titles via roleFuzzyMatch, and flags any company+role that
  * appears 2+ times with DIFFERENT URLs inside a rolling window (default 90d).
  * Such clusters are almost certainly the same opening being re-listed by the

--- a/server/lib/en-scanner.mjs
+++ b/server/lib/en-scanner.mjs
@@ -118,7 +118,7 @@ export async function runEnScan(opts = {}) {
   // "⬆ boosted" badge on those rows so the user can see WHY they're
   // ranked higher.
   const boosts = (tf.seniority_boost || []).map((s) => String(s).toLowerCase());
-  // v1.76.0 — optional trust validation (parent career-ops v1.13.0). Off unless
+  // v1.76.0 — optional trust validation. Off unless
   // `trust_filter:` is present and not disabled. Annotates each job with
   // _trustScore/_trustLevel/_trustFlags so the #/scan table can badge low-trust
   // postings — it NEVER drops a job.
@@ -193,8 +193,7 @@ export async function runEnScan(opts = {}) {
   }
 
   const allRaw = fetchedPerCo.flat();
-  // v1.33.0 (WS4 / parent #570) — optional portals.yml location_filter.
-  // Mirrors the parent scan.mjs semantics exactly. No key → pass-all.
+  // v1.33.0 (WS4) — optional portals.yml location_filter. No key → pass-all.
   const locOk = buildLocationFilter(portals.location_filter);
   // v1.75.0 (#974) — optional content_filter on a posting's description/snippet.
   // No key → pass-all; only sources that ship a description are affected.
@@ -222,7 +221,7 @@ export async function runEnScan(opts = {}) {
       return out;
     });
   const removedTitle = allRaw.length - filtered.length;
-  // v1.84.0 — re-apply cooldown (parent career-ops v1.15.0 / #1201). Drop roles
+  // v1.84.0 — re-apply cooldown. Drop roles
   // at companies you applied to recently, so the scan stays focused on NEW
   // openings. Config: config/profile.yml::re_apply_windows. Off when unset.
   const cooldownToday = new Date().toISOString().slice(0, 10);

--- a/server/lib/env-config.mjs
+++ b/server/lib/env-config.mjs
@@ -1,5 +1,5 @@
 /**
- * Read / write the project's .env file in place. Used by the
+ * Read / write the career-ops project's .env file in place. Used by the
  * /api/config endpoint so the user can edit ANTHROPIC_API_KEY, GEMINI_API_KEY,
  * etc. through the UI and have BOTH the CLI scripts (read by node) AND
  * web-ui (read by dotenv-loader) pick them up.

--- a/server/lib/env-config.mjs
+++ b/server/lib/env-config.mjs
@@ -1,7 +1,7 @@
 /**
- * Read / write the parent project's .env file in place. Used by the
+ * Read / write the project's .env file in place. Used by the
  * /api/config endpoint so the user can edit ANTHROPIC_API_KEY, GEMINI_API_KEY,
- * etc. through the UI and have BOTH career-ops scripts (read by node) AND
+ * etc. through the UI and have BOTH the CLI scripts (read by node) AND
  * web-ui (read by dotenv-loader) pick them up.
  *
  * Preserves existing comments and ordering; only the keys we touch are
@@ -157,7 +157,7 @@ export function parseEnv(text) {
  * v1.54.9 — effective value of an env key for runtime LLM routing.
  *
  * The server reads keys from `process.env`, which is a SNAPSHOT taken
- * at boot. If the user later sets `ANTHROPIC_API_KEY` in the parent
+ * at boot. If the user later sets `ANTHROPIC_API_KEY` in the
  * `.env` (or it was added after the server started) the running
  * process never sees it → `hasAnthropicKey()` is false, evaluation
  * silently falls through to whatever stale key IS in process.env
@@ -167,9 +167,9 @@ export function parseEnv(text) {
  * Resolution order, matching user expectation ("use whichever keys
  * are actually set"): a non-empty `process.env` value wins (covers
  * shell exports and the live-apply in POST /api/config), otherwise
- * the current parent `.env` file is consulted. This also removes the
- * asymmetry where the Gemini path (a parent Node subprocess) already
- * read the parent `.env` while the in-process Anthropic path did not.
+ * the current `.env` file is consulted. This also removes the
+ * asymmetry where the Gemini path (a Node subprocess) already
+ * read the `.env` while the in-process Anthropic path did not.
  *
  * Never throws; returns undefined when the key is set nowhere.
  */

--- a/server/lib/eval-validate.mjs
+++ b/server/lib/eval-validate.mjs
@@ -1,19 +1,18 @@
 /**
- * Evaluation-report shape validation (v1.75.0 — parent career-ops v1.12.0 #819
- * parity).
+ * Evaluation-report shape validation (v1.75.0).
  *
- * The parent's `gemini-eval.mjs` gained `validateEvaluationShape()` so a
- * malformed Gemini evaluation surfaces as an error instead of saving garbage.
- * web-ui's `/api/evaluate` Gemini branch shells out to that script, so it
- * inherits the guard. But web-ui ALSO runs evaluations IN-PROCESS through
- * Anthropic / OpenAI / Qwen / OpenRouter / GitHub Models — those responses were
- * returned with no shape check at all.
+ * The `/api/evaluate` Gemini branch shells out to a `gemini-eval.mjs` script
+ * whose `validateEvaluationShape()` makes a malformed Gemini evaluation surface
+ * as an error instead of saving garbage, so it inherits that guard. But web-ui
+ * ALSO runs evaluations IN-PROCESS through Anthropic / OpenAI / Qwen /
+ * OpenRouter / GitHub Models — those responses were returned with no shape
+ * check at all.
  *
- * This is the in-process analog. Unlike the parent (which throws to abort the
- * CLI), web-ui returns a list of issues so the route can attach them as a
- * non-fatal `warnings` array — the SPA still receives the artifact, but the
- * caller is told the report looks malformed (e.g. truncated by MAX_TOKENS).
- * Checks mirror the parent's `validateEvaluationShape` exactly.
+ * This is the in-process analog. Rather than throwing to abort a CLI, web-ui
+ * returns a list of issues so the route can attach them as a non-fatal
+ * `warnings` array — the SPA still receives the artifact, but the caller is
+ * told the report looks malformed (e.g. truncated by MAX_TOKENS). The checks
+ * mirror the `validateEvaluationShape` contract exactly.
  *
  * @param {string} text the model's evaluation markdown
  * @returns {string[]} issue messages — empty array means the shape is valid

--- a/server/lib/gemini.mjs
+++ b/server/lib/gemini.mjs
@@ -6,7 +6,7 @@
  * provider runners — `{ markdown, usage, error }` — so the llm.mjs router
  * treats every provider identically.
  *
- * Why this exists (v1.73.0): the parent `gemini-eval.mjs` is a purpose-built
+ * Why this exists (v1.73.0): the `gemini-eval.mjs` is a purpose-built
  * *oferta-evaluation* script — it reads cv.md/profile.yml and forces the A–G
  * scoring flow, treating its `--file` arg as a JD. Routing the GENERIC mode
  * and deep-research prompts through it produced an evaluation instead of the
@@ -17,7 +17,7 @@
  * gemini-eval.mjs.
  *
  * Key/model lookups go through effectiveEnv() (v1.54.9 contract): a key set in
- * the parent `.env` after boot is honoured without a restart.
+ * the `.env` after boot is honoured without a restart.
  */
 import { effectiveEnv, isUsableKey } from './env-config.mjs';
 import { PATHS } from './paths.mjs';

--- a/server/lib/html-entities.mjs
+++ b/server/lib/html-entities.mjs
@@ -1,13 +1,12 @@
 // Shared HTML-entity decoder for the in-process scraping sources whose feeds
-// return raw HTML (as opposed to a JSON API). Mirrors the parent project's
-// providers/_html-entities.mjs so the numeric-entity guard can't drift between
-// per-source copies.
+// return raw HTML (as opposed to a JSON API). Centralised so the numeric-entity
+// guard can't drift between per-source copies.
 //
 // Background: oraclecloud/gem/dassault each carried a copy that guarded only
 // with `Number.isFinite(code)` before calling `String.fromCodePoint(code)`.
 // That still throws a RangeError for a code point above 0x10FFFF (e.g.
 // `&#99999999;`), crashing the whole parse for a single malformed/adversarial
-// entity (parent #2150). Centralised here so the guard is defined once.
+// entity. Centralised here so the guard is defined once.
 //
 // The hex/decimal alternatives are matched separately (not `#x?[0-9a-fA-F]+`)
 // so a decimal entity can never absorb trailing hex letters — `&#1a2;` no

--- a/server/lib/http-json.mjs
+++ b/server/lib/http-json.mjs
@@ -8,10 +8,10 @@
  * helper there would log a skip-warning on every boot. Keeping it here avoids
  * that noise while staying reusable.
  *
- * Mirrors the parent providers' `ctx.fetchJson(url, opts)` contract:
+ * Provides the `fetchJson(url, opts)` contract:
  *   - GET by default; POST when `method`/`body` are supplied.
  *   - `redirect: 'error'` by default — refuses to follow server-side
- *     redirects, which closes the SSRF redirect vector the parent guards.
+ *     redirects, which closes the SSRF redirect vector.
  *   - Throws an Error with `.status` on a non-2xx response so callers can
  *     branch on outage vs empty-result.
  */
@@ -21,7 +21,7 @@
  * blocking a generic UA outright (seen live upstream: Glints' firewall,
  * Cloudflare-gated Workday tenants). Shared so every source working around
  * such a block bumps one constant instead of drifting Chrome versions
- * independently per file. Mirrors parent career-ops `providers/_http.mjs`.
+ * independently per file.
  */
 export const BROWSER_LIKE_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36';
@@ -30,8 +30,7 @@ export const BROWSER_LIKE_USER_AGENT =
  * undici's `err.cause.message` for a `fetch(url, { redirect: 'error' })` that
  * meets a 3xx. Undocumented and undici-internal, so it is pinned here (and by a
  * test) — if a Node upgrade changes the wording, `fetchJsonWithRetry` reverts to
- * over-retrying a deterministic failure, which the test catches loudly. Mirrors
- * parent career-ops `providers/_http.mjs` (#2657).
+ * over-retrying a deterministic failure, which the test catches loudly.
  */
 export const REDIRECT_REFUSAL_CAUSE_MESSAGE = 'unexpected redirect';
 
@@ -72,7 +71,7 @@ export async function fetchJson(fetchImpl, url, opts = {}) {
  * redirect it hit (jobvite distinguishes a feed pointing at NoJobs.htm — an
  * empty board — from a retired tenant) WITHOUT ever gaining the ability to
  * follow it. Both fields are null for a plain non-redirect error, so existing
- * `redirect:'error'` callers are unaffected. Mirrors parent `providers/_http.mjs`.
+ * `redirect:'error'` callers are unaffected.
  *
  * @param {typeof fetch} fetchImpl
  * @param {string} url
@@ -102,7 +101,7 @@ const NULL_BODY_STATUSES = new Set([204, 205, 304]);
  * Response-returning sibling of {@link fetchText}/{@link fetchJson} for the rare
  * source that needs the RESPONSE HEADERS. csod (Cornerstone) reads the bootstrap
  * home page's `Set-Cookie` to prime the session its search API demands — some
- * tenants answer `401 CSOD Unauthorized` without those cookies (parent #2769).
+ * tenants answer `401 CSOD Unauthorized` without those cookies.
  * Same SSRF stance (`redirect: 'error'` by default, so a 3xx can't be followed
  * to a private host). Non-2xx throws with `.status`, like the siblings.
  *
@@ -110,7 +109,7 @@ const NULL_BODY_STATUSES = new Set([204, 205, 304]);
  * Response: the body is read once here and handed back via `text()`, and
  * `headers` is passed through untouched so `headers.getSetCookie()` (repeated
  * Set-Cookie) still works on a real fetch — and a hand-rolled test stub can
- * expose whatever `headers` it likes. Mirrors parent `providers/_http.mjs`.
+ * expose whatever `headers` it likes.
  *
  * @param {typeof fetch} fetchImpl
  * @param {string} url
@@ -133,8 +132,7 @@ export async function fetchResponse(fetchImpl, url, opts = {}) {
 /**
  * Retrying sibling of {@link fetchJson} for feeds that paginate into the
  * hundreds of pages, where a single transient upstream blip mid-sweep used to
- * abort the whole provider and return nothing (parent career-ops #2506,
- * `providers/_http.mjs::fetchJsonWithRetry`). Retries ONLY transient failures —
+ * abort the whole provider and return nothing. Retries ONLY transient failures —
  * HTTP 429, HTTP ≥ 500, and network/timeout errors that carry no `.status` —
  * with an abort-aware backoff. A permanent 4xx (e.g. 404) is NOT retried: it is
  * rethrown immediately so the caller's dead-board logic still fires. Once the
@@ -146,7 +144,7 @@ export async function fetchResponse(fetchImpl, url, opts = {}) {
  * as a transient network error — but it is deterministic and will never succeed
  * on retry, so retrying it just burns the whole budget before failing. It is
  * distinguished by `err.cause.message === 'unexpected redirect'` and classified
- * non-retryable (parent career-ops #2657; the wording is undici-internal and
+ * non-retryable (the wording is undici-internal and
  * pinned by a test so a silent revert to over-retrying fails loudly. Node < 18.5
  * reports `cause` as undefined, so the check simply doesn't fire there and the
  * old — retryable — classification stands).
@@ -168,7 +166,7 @@ export async function fetchJsonWithRetry(fetchImpl, url, opts = {}) {
       lastErr = err;
       const status = err && typeof err.status === 'number' ? err.status : undefined;
       // A refused redirect looks like a no-status network error but is
-      // deterministic — never retry it (parent #2657).
+      // deterministic — never retry it.
       const redirectRefusal = status === undefined
         && err instanceof TypeError
         && err?.cause?.message === REDIRECT_REFUSAL_CAUSE_MESSAGE;

--- a/server/lib/llm-usage.mjs
+++ b/server/lib/llm-usage.mjs
@@ -2,7 +2,7 @@
  * LLM usage recorder + aggregator (v1.105.0).
  *
  * Every LIVE provider call (from `runActiveProvider` and `routes/llm.mjs`)
- * appends one JSONL line — `{ ts, provider, in, out }` — to the parent user
+ * appends one JSONL line — `{ ts, provider, in, out }` — to the user
  * layer at `data/llm-usage.jsonl`. The Usage page reads it back and rolls it up
  * per provider over time windows, turning token counts into an *estimated* USD
  * cost via the editable `llm-pricing.mjs` table.
@@ -27,7 +27,7 @@ export function normalizeUsage(u) {
 }
 
 /** Append one usage record. `provider` is the mode string; `usage` is raw.
- *  `file` defaults to the parent-layer log; tests pass an isolated temp path. */
+ *  `file` defaults to the user-layer log; tests pass an isolated temp path. */
 export function recordUsage(provider, usage, nowMs, file = PATHS.llmUsage) {
   try {
     const { in: inp, out } = normalizeUsage(usage);

--- a/server/lib/location-filter.mjs
+++ b/server/lib/location-filter.mjs
@@ -1,12 +1,10 @@
 /**
- * v1.33.0 (WS4) — `location_filter` parity with parent career-ops 1.8.0 (#570).
+ * v1.33.0 (WS4) — `location_filter` support.
  *
- * Parent's `scan.mjs` gained an optional `location_filter` block in
- * `portals.yml`. web-ui runs its OWN in-process scanners
- * (`en-scanner.mjs` / `ru-scanner.mjs`) — they do NOT shell out to the
- * parent's `scan.mjs`, so the parent feature does not flow through
- * automatically. This module mirrors the parent's `buildLocationFilter`
- * semantics EXACTLY so both scanners gain the same behaviour.
+ * `portals.yml` may carry an optional `location_filter` block. web-ui runs its
+ * OWN in-process scanners (`en-scanner.mjs` / `ru-scanner.mjs`), so this module
+ * implements the `buildLocationFilter` semantics directly and both scanners
+ * gain the same behaviour.
  *
  * portals.yml:
  *   location_filter:
@@ -23,7 +21,7 @@
  */
 
 // ── Title filter ────────────────────────────────────────────────────
-// v1.76.0 — parity with parent career-ops v1.13.0 scan.mjs (#1102, #1187).
+// v1.76.0 — title-filter matching robustness.
 // Two robustness fixes over the old `title.includes(keyword)` approach:
 //   1. Short all-letter acronyms (2-3 chars: cfo, coo, sdr, bdr, gsi…) match on
 //      WORD BOUNDARIES, so "COO" no longer matches "Coordinator" and "SDR" no
@@ -48,7 +46,7 @@ export function compileKeyword(kw) {
 /**
  * An AND-group: whitespace-delimited ` + ` between terms in a single
  * `title_filter.positive` entry means EVERY term must appear in the title, in
- * any order (parent career-ops #2552). `title_filter.positive` is otherwise a
+ * any order. `title_filter.positive` is otherwise a
  * hand-maintained list of literal spellings, and real titles vary in word order
  * and separators — an AND-group lets one entry require a conjunction
  * ("staff + platform") without enumerating every ordering. The surrounding
@@ -82,7 +80,7 @@ export function compilePositiveKeyword(kw) {
  * @returns {Array<(lower: string) => boolean>}
  */
 export function compileKeywordList(arr, compiler = compileKeyword) {
-  // v1.79.0 — trim BEFORE the length check (parent career-ops v1.14.0 #1261):
+  // v1.79.0 — trim BEFORE the length check:
   // a whitespace-only keyword ("  ") otherwise survives length>0 and compiles
   // into a substring matcher that matches almost everything.
   return (Array.isArray(arr) ? arr : [])
@@ -130,13 +128,13 @@ export function buildLocationFilter(locationFilter) {
 }
 
 /**
- * v1.75.0 — `content_filter` parity with parent career-ops 1.12.0 (#974).
+ * v1.75.0 — `content_filter` support.
  *
  * Like `location_filter` but matches against a posting's free-text
  * description/snippet rather than its location. Only sources that populate a
  * `description` (or `snippet`) field are affected — every other posting passes,
  * so enabling this never silently drops postings from sources that don't ship a
- * body. Semantics mirror the parent's `buildContentFilter` exactly.
+ * body.
  *
  * portals.yml:
  *   content_filter:

--- a/server/lib/openai.mjs
+++ b/server/lib/openai.mjs
@@ -12,7 +12,7 @@
  * (`runOpenAICompatible`) backs the thin wrappers.
  *
  * Key/model lookups go through effectiveEnv() (v1.54.9 contract): a
- * key set in the parent `.env` after boot is honoured without a
+ * key set in the `.env` after boot is honoured without a
  * restart, and DETECTION (has*Key) matches the key the request SENDS.
  */
 import { effectiveEnv, isUsableKey } from './env-config.mjs';

--- a/server/lib/parent-relay.mjs
+++ b/server/lib/parent-relay.mjs
@@ -1,5 +1,5 @@
 /**
- * Shared helpers for routes that shell out to parent career-ops scripts
+ * Shared helpers for routes that shell out to the companion CLI scripts
  * (followup-cadence.mjs, followup-seed.mjs, analyze-patterns.mjs) and relay
  * their JSON stdout. Consolidates the v1.117.1 parse rule and the v1.117.2
  * empty-tracker contract in one place so the two consumers can't drift.
@@ -8,7 +8,7 @@ import { PROJECT_ROOT } from './paths.mjs';
 
 /**
  * Parse a script's stdout as JSON. The whole trimmed stdout is tried FIRST
- * (the parent scripts print a single JSON document), and only on failure do
+ * (these scripts print a single JSON document), and only on failure do
  * we fall back to slicing from the first `{` — so a stray {…}-shaped log
  * line before the payload can't silently win over the real document
  * (v1.117.1 review).
@@ -29,7 +29,7 @@ export function parseJsonStdout(stdout) {
 }
 
 /**
- * The parent scripts exit 1 with a structured {error} on stdout for exactly
+ * These scripts exit 1 with a structured {error} on stdout for exactly
  * two benign "no data yet" cases (followup-cadence.mjs:287,
  * analyze-patterns.mjs:411,445). Only THOSE messages count as a healthy
  * empty state — any other {error} must fall through to the honest

--- a/server/lib/parsers.mjs
+++ b/server/lib/parsers.mjs
@@ -260,7 +260,7 @@ export function scoreStringToNum(s) {
 
 /**
  * FIX-1 — the language-invariant `## Machine Summary` block body, or '' when
- * the report has none. The heading itself is emitted in English by the parent
+ * the report has none. The heading itself is emitted in English by the
  * oferta template regardless of the report's prose locale, so its `score:` /
  * `legitimacy:` / `date:` YAML keys are the reliable, locale-free source.
  */

--- a/server/lib/paths.mjs
+++ b/server/lib/paths.mjs
@@ -9,7 +9,7 @@ export const WEB_UI_ROOT = resolve(__dirname, '..', '..');
 export const PUBLIC_DIR = resolve(WEB_UI_ROOT, 'public');
 
 /**
- * Resolve where the parent career-ops project lives:
+ * Resolve where the project root lives:
  *   1. CAREER_OPS_ROOT env var (absolute or relative to cwd)
  *   2. ../  (when this repo is dropped in as career-ops/web-ui)
  *   3. cwd  (when launched from inside career-ops itself)
@@ -89,10 +89,10 @@ export const PATHS = {
   // layer on explicit Save; never overwritten by system updates.
   careerPlan: path('config', 'career-plan.md'),
   portals: path('portals.yml'),
-  // v1.128.0 — the parent's canonical application-state definitions
+  // v1.128.0 — the canonical application-state definitions
   // (id/label/aliases/dashboard_group). System layer, read-only; the tracker
-  // reads it live instead of hardcoding a status whitelist (parent web/ port
-  // #2 — see server/lib/states.mjs). A hardcoded fallback covers CI isolation.
+  // reads it live instead of hardcoding a status whitelist (see
+  // server/lib/states.mjs). A hardcoded fallback covers CI isolation.
   statesYml: path('templates', 'states.yml'),
   packageJson: path('package.json'),
   version: path('VERSION'),

--- a/server/lib/paths.mjs
+++ b/server/lib/paths.mjs
@@ -9,7 +9,7 @@ export const WEB_UI_ROOT = resolve(__dirname, '..', '..');
 export const PUBLIC_DIR = resolve(WEB_UI_ROOT, 'public');
 
 /**
- * Resolve where the project root lives:
+ * Resolve where the career-ops project root lives:
  *   1. CAREER_OPS_ROOT env var (absolute or relative to cwd)
  *   2. ../  (when this repo is dropped in as career-ops/web-ui)
  *   3. cwd  (when launched from inside career-ops itself)

--- a/server/lib/portals/adapters/alibaba.mjs
+++ b/server/lib/portals/adapters/alibaba.mjs
@@ -1,9 +1,9 @@
 /**
- * Alibaba adapter (registry contract). Parent career-ops parity.
+ * Alibaba adapter (registry contract).
  *
  * Single-company Chinese tech board. Matches on an explicit
- * `provider: alibaba` OR a careers_url/api whose host is talent.alibaba.com
- * (mirroring the parent's `detect`). The JSON API endpoint is fixed; per-entry
+ * `provider: alibaba` OR a careers_url/api whose host is talent.alibaba.com.
+ * The JSON API endpoint is fixed; per-entry
  * search config (`keywords` / `max_pages`) is read by the source from
  * `opts.company`. The source-level assertAlibabaUrl is the hard SSRF guard.
  *

--- a/server/lib/portals/adapters/amazon.mjs
+++ b/server/lib/portals/adapters/amazon.mjs
@@ -1,11 +1,11 @@
 /**
- * Amazon / AWS adapter (registry contract). Parent career-ops parity.
+ * Amazon / AWS adapter (registry contract).
  *
  * The amazon.jobs board is one global endpoint, so a tracked_companies entry
  * narrows it with an `amazon:` config block (loc_query / base_query / category …)
  * whose keys pass straight through as query params. It matches on an explicit
- * `provider: amazon` OR a careers_url/api whose host is amazon.jobs (mirroring the
- * parent's `detect`). The endpoint is host-pinned to www.amazon.jobs; the
+ * `provider: amazon` OR a careers_url/api whose host is amazon.jobs. The endpoint
+ * is host-pinned to www.amazon.jobs; the
  * source-level assertAmazonUrl is the hard SSRF guard.
  *
  *   tracked_companies:

--- a/server/lib/portals/adapters/avature.mjs
+++ b/server/lib/portals/adapters/avature.mjs
@@ -1,6 +1,5 @@
 /**
- * Avature adapter (registry contract). Parent career-ops `providers/avature.mjs`
- * parity.
+ * Avature adapter (registry contract).
  *
  * Avature is a per-tenant ATS: each company runs its own `*.avature.net` origin
  * (or a branded custom domain proxying Avature). It matches on either:

--- a/server/lib/portals/adapters/bamboohr.mjs
+++ b/server/lib/portals/adapters/bamboohr.mjs
@@ -1,5 +1,5 @@
 /**
- * BambooHR adapter (registry contract). Parent career-ops v1.13.0 parity.
+ * BambooHR adapter (registry contract).
  *
  * Detects a BambooHR tenant from a `careers_url`/`api:` whose host matches
  * `<tenant>.bamboohr.com`, or from an explicit `provider: bamboohr`. The HTTP

--- a/server/lib/portals/adapters/beesite.mjs
+++ b/server/lib/portals/adapters/beesite.mjs
@@ -1,5 +1,5 @@
 /**
- * beesite (milch & zucker GJB) adapter (registry contract). Parent parity (v1.117.0).
+ * beesite (milch & zucker GJB) adapter (registry contract).
  *
  * Per-tenant: matches an explicit `provider: beesite` OR a careers_url/api on a
  * *.beesite.de host (the search backend behind branded portals like

--- a/server/lib/portals/adapters/breezy.mjs
+++ b/server/lib/portals/adapters/breezy.mjs
@@ -1,5 +1,5 @@
 /**
- * Breezy HR adapter (registry contract). Parent career-ops v1.13.0 parity.
+ * Breezy HR adapter (registry contract).
  *
  * Detects a Breezy tenant from a `careers_url`/`api:` whose host matches
  * `<tenant>.breezy.hr`, or from an explicit `provider: breezy`. The HTTP fetch +

--- a/server/lib/portals/adapters/comeet.mjs
+++ b/server/lib/portals/adapters/comeet.mjs
@@ -1,5 +1,5 @@
 /**
- * Comeet adapter (registry contract). Parent career-ops v1.13.0 parity.
+ * Comeet adapter (registry contract).
  *
  * Matches when `api:` (or `careers_url`) is a full Comeet careers-api URL, or on
  * an explicit `provider: comeet`. The HTTP fetch + normalization lives in

--- a/server/lib/portals/adapters/consider.mjs
+++ b/server/lib/portals/adapters/consider.mjs
@@ -1,5 +1,5 @@
 /**
- * Consider adapter (registry contract). Parent career-ops parity.
+ * Consider adapter (registry contract).
  *
  * getconsider.com VC portfolio "talent network" boards. Matches ONLY on an
  * explicit `provider: consider` field — never on careers_url alone — because

--- a/server/lib/portals/adapters/cryptocurrencyjobs.mjs
+++ b/server/lib/portals/adapters/cryptocurrencyjobs.mjs
@@ -1,5 +1,5 @@
 /**
- * Cryptocurrency Jobs adapter (registry contract). Parent career-ops parity.
+ * Cryptocurrency Jobs adapter (registry contract).
  *
  * A board-wide aggregator, so it matches ONLY on an explicit
  * `provider: cryptocurrencyjobs` field — never on careers_url. The endpoint is

--- a/server/lib/portals/adapters/dassault.mjs
+++ b/server/lib/portals/adapters/dassault.mjs
@@ -1,10 +1,9 @@
 /**
- * Dassault Systèmes adapter (registry contract). Parent career-ops parity
- * (parent `providers/dassault.mjs`, #1498).
+ * Dassault Systèmes adapter (registry contract).
  *
  * Single global Exalead endpoint (like ibm / amazon), so a tracked_companies
  * entry selects it explicitly with `provider: dassault` OR via a careers_url/api
- * whose host is 3ds.com (mirroring the parent's `detect`). The endpoint is
+ * whose host is 3ds.com. The endpoint is
  * host-pinned to www.3ds.com; the source-level assertDassaultUrl is the hard
  * SSRF guard.
  *

--- a/server/lib/portals/adapters/deutschebahn.mjs
+++ b/server/lib/portals/adapters/deutschebahn.mjs
@@ -1,11 +1,10 @@
 /**
- * Deutsche Bahn adapter (registry contract). Parent career-ops parity
- * (parent `providers/deutschebahn.mjs`).
+ * Deutsche Bahn adapter (registry contract).
  *
  * Single-company careers board on db.jobs (like ibm / dassault / tkms). A
  * tracked_companies entry selects it explicitly with `provider: deutschebahn`
- * OR via a careers_url/api whose host is db.jobs (mirroring the parent's
- * detect). The endpoint is host-pinned to db.jobs; the source-level
+ * OR via a careers_url/api whose host is db.jobs. The endpoint is host-pinned
+ * to db.jobs; the source-level
  * resolveConfig is the hard SSRF guard.
  *
  *   tracked_companies:

--- a/server/lib/portals/adapters/echojobs.mjs
+++ b/server/lib/portals/adapters/echojobs.mjs
@@ -1,10 +1,9 @@
 /**
- * EchoJobs adapter (registry contract). Parent career-ops parity
- * (parent `providers/echojobs.mjs`).
+ * EchoJobs adapter (registry contract).
  *
  * Board-wide public JSON aggregator — no per-tenant host — so a tracked_companies
- * entry selects it explicitly with `provider: echojobs` (mirroring the parent's
- * detect). The feed is fixed and host-pinned to echojobs.io inside the source.
+ * entry selects it explicitly with `provider: echojobs`. The feed is fixed and
+ * host-pinned to echojobs.io inside the source.
  *
  *   tracked_companies:
  *     - name: EchoJobs

--- a/server/lib/portals/adapters/eightfold.mjs
+++ b/server/lib/portals/adapters/eightfold.mjs
@@ -1,12 +1,10 @@
 /**
- * Eightfold AI adapter (registry contract). Parent career-ops
- * `providers/eightfold.mjs` parity (#2684).
+ * Eightfold AI adapter (registry contract).
  *
  * Eightfold is a per-tenant ATS: each company runs its own branded board at
  * `<tenant>.eightfold.ai`. It matches on either:
  *   - an explicit `provider: eightfold`, or
- *   - a `careers_url` / `api:` whose host matches the *.eightfold.ai pattern
- *     (mirroring the parent's host-pinned `detect`).
+ *   - a `careers_url` / `api:` whose host matches the *.eightfold.ai pattern.
  *
  * The endpoint is the pinned `https://<tenant>.eightfold.ai/api/apply/v2/jobs`
  * built from the entry's own `api:`/careers_url. The override host is

--- a/server/lib/portals/adapters/getonbrd.mjs
+++ b/server/lib/portals/adapters/getonbrd.mjs
@@ -1,5 +1,5 @@
 /**
- * Get on Board adapter (registry contract). Parent career-ops parity.
+ * Get on Board adapter (registry contract).
  *
  * A board-wide aggregator, so it matches ONLY on an explicit `provider: getonbrd`
  * field — never on careers_url. The endpoint is the fixed public category feed,

--- a/server/lib/portals/adapters/getro.mjs
+++ b/server/lib/portals/adapters/getro.mjs
@@ -1,5 +1,5 @@
 /**
- * Getro adapter (registry contract). Parent career-ops parity.
+ * Getro adapter (registry contract).
  *
  * VC "talent network" portfolio boards (b2venture, Earlybird, Point Nine …),
  * each addressed by a numeric `getro_collection`. Board-wide / per-collection,

--- a/server/lib/portals/adapters/hecklerkoch.mjs
+++ b/server/lib/portals/adapters/hecklerkoch.mjs
@@ -1,11 +1,10 @@
 /**
- * Heckler & Koch adapter (registry contract). Parent career-ops parity
- * (parent `providers/hecklerkoch.mjs`).
+ * Heckler & Koch adapter (registry contract).
  *
  * Single-company SSR list (like dassault / rheinmetall), so a tracked_companies
  * entry selects it explicitly with `provider: hecklerkoch` OR via a
- * careers_url/api whose host is heckler-koch.com (mirroring the parent's
- * `detect`). The endpoint is host-pinned; the source-level
+ * careers_url/api whose host is heckler-koch.com. The endpoint is host-pinned;
+ * the source-level
  * assertHecklerkochUrl is the hard SSRF guard.
  *
  *   tracked_companies:

--- a/server/lib/portals/adapters/higheredjobs.mjs
+++ b/server/lib/portals/adapters/higheredjobs.mjs
@@ -1,5 +1,5 @@
 /**
- * HigherEdJobs adapter (registry contract). Parent career-ops parity (v1.117.0).
+ * HigherEdJobs adapter (registry contract).
  *
  * A board-wide aggregator, so it matches ONLY on an explicit
  * `provider: higheredjobs` field — never on careers_url. The endpoint is the

--- a/server/lib/portals/adapters/icims.mjs
+++ b/server/lib/portals/adapters/icims.mjs
@@ -1,5 +1,5 @@
 /**
- * iCIMS adapter (registry contract). Parent career-ops parity.
+ * iCIMS adapter (registry contract).
  *
  * Targets the classic iCIMS hosted-portal search pages at
  * `careers-<tenant>.icims.com` — DISTINCT from the `jibeapply` adapter, which

--- a/server/lib/portals/adapters/jibeapply.mjs
+++ b/server/lib/portals/adapters/jibeapply.mjs
@@ -1,5 +1,5 @@
 /**
- * JibeApply adapter (registry contract). Parent career-ops parity (v1.117.0).
+ * JibeApply adapter (registry contract).
  *
  * Per-tenant: matches an explicit `provider: jibeapply` OR a careers_url on a
  * *.jibeapply.com host. Branded iCIMS-hosted tenants that share the same JSON

--- a/server/lib/portals/adapters/jobvite.mjs
+++ b/server/lib/portals/adapters/jobvite.mjs
@@ -1,6 +1,5 @@
 /**
- * Jobvite adapter (registry contract). Parent career-ops `providers/jobvite.mjs`
- * (#2623 XML-feed migration) parity.
+ * Jobvite adapter (registry contract).
  *
  * Jobvite is a per-tenant ATS across TWO fixed hosts: the board lives on
  * `jobs.jobvite.com` (keyed by a vanity slug) and the public jobs feed on

--- a/server/lib/portals/adapters/join.mjs
+++ b/server/lib/portals/adapters/join.mjs
@@ -1,8 +1,8 @@
 /**
- * JOIN (join.com) adapter (registry contract). Parent career-ops parity.
+ * JOIN (join.com) adapter (registry contract).
  *
  * join.com hosts one board per company at https://join.com/companies/<slug>, so
- * detection is host-based (mirrors the parent provider's `detect`): the entry
+ * detection is host-based: the entry
  * matches when its careers_url is a join.com/companies/<slug> URL. The endpoint
  * is the bare careers_url — the source (server/lib/sources/join.mjs) re-extracts
  * the slug and rebuilds the host-pinned https://join.com/companies/<slug> base,

--- a/server/lib/portals/adapters/joinup.mjs
+++ b/server/lib/portals/adapters/joinup.mjs
@@ -1,9 +1,9 @@
 /**
- * joinup.ch adapter (registry contract). Parent career-ops parity.
+ * joinup.ch adapter (registry contract).
  *
  * joinup is a board-wide feed of Swiss startup jobs, auto-detected from a
- * `careers_url` whose host is joinup.ch (mirrors the parent provider's
- * hostname-anchored `detect`). The endpoint is the fixed, host-pinned browse
+ * `careers_url` whose host is joinup.ch. The endpoint is the fixed, host-pinned
+ * browse
  * page (BROWSE_URL); the source fetches that constant regardless, so the
  * adapter simply gates on the host match.
  *

--- a/server/lib/portals/adapters/larajobs.mjs
+++ b/server/lib/portals/adapters/larajobs.mjs
@@ -1,6 +1,5 @@
 /**
- * LaraJobs adapter (registry contract). Parent career-ops parity
- * (parent `providers/larajobs.mjs`).
+ * LaraJobs adapter (registry contract).
  *
  * A board-wide aggregator (like nodesk / weworkremotely), so it matches ONLY
  * on an explicit `provider: larajobs` field — never on careers_url. The

--- a/server/lib/portals/adapters/lever.mjs
+++ b/server/lib/portals/adapters/lever.mjs
@@ -2,7 +2,7 @@
  * Lever adapter (v1.13.0 registry contract).
  *
  * Detects Lever boards from `careers_url` like `jobs.lever.co/<slug>` or the
- * EU tenancy `jobs.eu.lever.co/<slug>` (parent v1.18.0 parity, Lever EU) and
+ * EU tenancy `jobs.eu.lever.co/<slug>` (Lever EU) and
  * the explicit `api:` field. The API host mirrors the board host —
  * api.lever.co for the US tenancy, api.eu.lever.co for the EU one. Delegates
  * the fetch to server/lib/sources/lever.mjs (preserved verbatim).

--- a/server/lib/portals/adapters/manfred.mjs
+++ b/server/lib/portals/adapters/manfred.mjs
@@ -1,9 +1,9 @@
 /**
- * getManfred adapter (registry contract). Parent career-ops parity.
+ * getManfred adapter (registry contract).
  *
  * A board-wide feed of Spanish/EU tech jobs, so it matches ONLY on an explicit
- * `provider: manfred` field — never on careers_url (the parent provider's
- * `detect` is provider-selection only). The endpoint is the fixed public offers
+ * `provider: manfred` field — never on careers_url (detection is
+ * provider-selection only). The endpoint is the fixed public offers
  * feed, overridable via `manfred:` / `api:` (host-pinned to www.getmanfred.com)
  * for testing or a mirror. The required `lang` query parameter is appended by
  * the source from the portal entry, so the adapter's endpoint stays the bare

--- a/server/lib/portals/adapters/meituan.mjs
+++ b/server/lib/portals/adapters/meituan.mjs
@@ -1,9 +1,9 @@
 /**
- * Meituan adapter (registry contract). Parent career-ops parity (#1818).
+ * Meituan adapter (registry contract).
  *
  * Single-company Chinese tech board. Matches on an explicit
- * `provider: meituan` OR a careers_url/api whose host is zhaopin.meituan.com
- * (mirroring the parent's `detect`). The JSON API endpoint is fixed; per-entry
+ * `provider: meituan` OR a careers_url/api whose host is zhaopin.meituan.com.
+ * The JSON API endpoint is fixed; per-entry
  * search config (`keywords` / `max_pages`) is read by the source from
  * `opts.company`. The source-level assertMeituanUrl is the hard SSRF guard.
  *

--- a/server/lib/portals/adapters/nodesk.mjs
+++ b/server/lib/portals/adapters/nodesk.mjs
@@ -1,5 +1,5 @@
 /**
- * NoDesk adapter (registry contract). Parent career-ops v1.15.0 parity.
+ * NoDesk adapter (registry contract).
  *
  * A board-wide aggregator, so it matches ONLY on an explicit `provider: nodesk`
  * field — never on careers_url. The endpoint is the fixed public RSS feed,

--- a/server/lib/portals/adapters/oraclecloud.mjs
+++ b/server/lib/portals/adapters/oraclecloud.mjs
@@ -1,6 +1,5 @@
 /**
- * Oracle Recruiting Cloud (ORC) adapter (registry contract). Parent career-ops
- * `providers/oraclecloud.mjs` parity.
+ * Oracle Recruiting Cloud (ORC) adapter (registry contract).
  *
  * ORC is a per-tenant ATS: each company runs its own Fusion Candidate
  * Experience host (`<tenant>.fa[.<region>][.ocs].oraclecloud.com`). It matches

--- a/server/lib/portals/adapters/personio.mjs
+++ b/server/lib/portals/adapters/personio.mjs
@@ -1,5 +1,5 @@
 /**
- * Personio adapter (registry contract). Parent career-ops v1.13.0 parity.
+ * Personio adapter (registry contract).
  *
  * Detects a Personio tenant from a `careers_url`/`api:` whose host matches
  * `<slug>.jobs.personio.(de|com)`, or from an explicit `provider: personio`.

--- a/server/lib/portals/adapters/radancy.mjs
+++ b/server/lib/portals/adapters/radancy.mjs
@@ -2,7 +2,7 @@
  * Radancy (TalentBrew) adapter (registry contract). Per-tenant ATS.
  *
  * Branded hosts carry no stable Radancy token in the URL, so there is NO
- * auto-detection (parent parity) — tenants are wired with an explicit
+ * auto-detection — tenants are wired with an explicit
  * `provider: radancy` plus a search-jobs `api:`/careers_url. The endpoint is
  * the tenant's SSR /{lang}/search-jobs list URL; the ?p=N paged HTML walk
  * lives in server/lib/sources/radancy.mjs.

--- a/server/lib/portals/adapters/recruitee.mjs
+++ b/server/lib/portals/adapters/recruitee.mjs
@@ -1,5 +1,5 @@
 /**
- * Recruitee adapter (registry contract). Parent career-ops parity.
+ * Recruitee adapter (registry contract).
  *
  * Detects a Recruitee tenant from a `careers_url`/`api:` whose host matches
  * `<slug>.recruitee.com`, or from an explicit `provider: recruitee`. The HTTP

--- a/server/lib/portals/adapters/remotli.mjs
+++ b/server/lib/portals/adapters/remotli.mjs
@@ -1,9 +1,9 @@
 /**
- * Remotli adapter (registry contract). Parent career-ops parity.
+ * Remotli adapter (registry contract).
  *
  * remotli.ch is a board-wide curated feed of remote roles at Swiss companies, so
- * a single tracked entry claims the whole board. Detection mirrors the parent's
- * host-based `detect`: a careers_url on remotli.ch, or an explicit
+ * a single tracked entry claims the whole board. Detection is host-based: a
+ * careers_url on remotli.ch, or an explicit
  * `provider: remotli`. The endpoint is the fixed, host-pinned first-page base
  * (`https://remotli.ch/api/jobs`); the source appends `?page=N&limit=50&remote=all`
  * itself, so the adapter's endpoint stays the bare base. assertRemotliUrl in the

--- a/server/lib/portals/adapters/rheinmetall.mjs
+++ b/server/lib/portals/adapters/rheinmetall.mjs
@@ -1,11 +1,10 @@
 /**
- * Rheinmetall adapter (registry contract). Parent career-ops parity
- * (parent `providers/rheinmetall.mjs`).
+ * Rheinmetall adapter (registry contract).
  *
  * Single-company SSR list (like dassault / hecklerkoch), so a tracked_companies
  * entry selects it explicitly with `provider: rheinmetall` OR via a
- * careers_url/api whose host is rheinmetall.com (mirroring the parent's
- * `detect`). The endpoint is a plain list URL — the `?page=N` pagination lives
+ * careers_url/api whose host is rheinmetall.com. The endpoint is a plain list
+ * URL — the `?page=N` pagination lives
  * inside the fetcher, driven by opts.company (established repo rule). The
  * source-level assertRheinmetallUrl is the hard SSRF guard.
  *

--- a/server/lib/portals/adapters/softgarden.mjs
+++ b/server/lib/portals/adapters/softgarden.mjs
@@ -1,5 +1,5 @@
 /**
- * softgarden adapter (registry contract). Parent career-ops parity (v1.117.0).
+ * softgarden adapter (registry contract).
  *
  * Per-tenant: matches an explicit `provider: softgarden` OR a careers_url/api
  * on a *.softgarden.io host. The endpoint is the tenant's server-rendered

--- a/server/lib/portals/adapters/solidjobs.mjs
+++ b/server/lib/portals/adapters/solidjobs.mjs
@@ -1,5 +1,5 @@
 /**
- * SolidJobs adapter (registry contract). Parent career-ops parity.
+ * SolidJobs adapter (registry contract).
  *
  * Matches when `careers_url` (or `api:`) is a SolidJobs public-api offers URL, or
  * on an explicit `provider: solidjobs`. The HTTP fetch + normalization lives in

--- a/server/lib/portals/adapters/successfactors.mjs
+++ b/server/lib/portals/adapters/successfactors.mjs
@@ -1,5 +1,5 @@
 /**
- * SAP SuccessFactors (RMK) adapter (registry contract). Parent career-ops parity.
+ * SAP SuccessFactors (RMK) adapter (registry contract).
  *
  * Matches either an explicit `provider: successfactors` OR a `careers_url`/`api:`
  * whose host is a literal *.successfactors.(eu|com) / jobs2web.com — the branded
@@ -33,7 +33,7 @@ export const successfactorsAdapter = {
     }
   },
   buildEndpoint(company) {
-    // Parent #2099: keep a brand/tenant path prefix (multi-brand RMK
+    // Keep a brand/tenant path prefix (multi-brand RMK
     // holdings) — resolveTenantBase strips only trailing endpoint segments.
     const base = resolveTenantBase(company);
     return base ? `${base}/tile-search-results/` : null;

--- a/server/lib/portals/adapters/tencent.mjs
+++ b/server/lib/portals/adapters/tencent.mjs
@@ -1,9 +1,9 @@
 /**
- * Tencent adapter (registry contract). Parent career-ops parity (#230).
+ * Tencent adapter (registry contract).
  *
  * Single-company Chinese tech board. Matches on an explicit
- * `provider: tencent` OR a careers_url/api whose host is careers.tencent.com
- * (mirroring the parent's `detect`). The JSON API endpoint is fixed; per-entry
+ * `provider: tencent` OR a careers_url/api whose host is careers.tencent.com.
+ * The JSON API endpoint is fixed; per-entry
  * search config (`keywords` / `max_pages`) is read by the source from
  * `opts.company`. The source-level assertTencentUrl is the hard SSRF guard.
  *

--- a/server/lib/portals/adapters/tkms.mjs
+++ b/server/lib/portals/adapters/tkms.mjs
@@ -1,11 +1,10 @@
 /**
- * TKMS (thyssenkrupp Marine Systems) adapter (registry contract). Parent
- * career-ops parity (parent `providers/tkms.mjs`).
+ * TKMS (thyssenkrupp Marine Systems) adapter (registry contract).
  *
  * Single-employer careers app on jobs.tkmsgroup.com (like ibm / dassault). A
  * tracked_companies entry selects it explicitly with `provider: tkms` OR via a
- * careers_url/api whose host is jobs.tkmsgroup.com (mirroring the parent's
- * detect). The endpoint is host-pinned; the source-level resolveConfig is the
+ * careers_url/api whose host is jobs.tkmsgroup.com. The endpoint is host-pinned;
+ * the source-level resolveConfig is the
  * hard SSRF guard. buildEndpoint returns the POST query API URL (a string) —
  * the subclient/locale/page POST body lives inside the fetcher, driven by
  * opts.company.

--- a/server/lib/portals/adapters/weworkremotely.mjs
+++ b/server/lib/portals/adapters/weworkremotely.mjs
@@ -1,5 +1,5 @@
 /**
- * We Work Remotely adapter (registry contract). Parent career-ops v1.14.0 parity.
+ * We Work Remotely adapter (registry contract).
  *
  * A board-wide aggregator, so it matches ONLY on an explicit
  * `provider: weworkremotely` field — never on careers_url. The endpoint is the

--- a/server/lib/portals/adapters/workday.mjs
+++ b/server/lib/portals/adapters/workday.mjs
@@ -12,7 +12,7 @@
  *
  * If the customer's site lives behind a CAPTCHA or non-standard path,
  * the adapter throws — we recommend falling back to `/career-ops scan`
- * (parent CLI, drives a real browser via Playwright).
+ * (drives a real browser via Playwright).
  */
 import { fetchWorkday } from '../../sources/workday.mjs';
 

--- a/server/lib/portals/registry.mjs
+++ b/server/lib/portals/registry.mjs
@@ -29,29 +29,29 @@ import { workableAdapter } from './adapters/workable.mjs';
 import { smartRecruitersAdapter } from './adapters/smartrecruiters.mjs';
 import { workdayAdapter } from './adapters/workday.mjs';
 import { rssAdapter } from './adapters/rss.mjs';
-// v1.75.0 — parent v1.12.0 parity: board-wide remote aggregators.
+// v1.75.0 — board-wide remote aggregators.
 import { remoteokAdapter } from './adapters/remoteok.mjs';
 import { remotiveAdapter } from './adapters/remotive.mjs';
 import { workingNomadsAdapter } from './adapters/workingnomads.mjs';
-// v1.75.0 — parent v1.12.0 parity: config-driven regional aggregators.
+// v1.75.0 — config-driven regional aggregators.
 // These read per-entry config (the `<provider>:` block) from `opts.company`,
 // which en-scanner now threads through to every fetcher.
 import { ibmAdapter } from './adapters/ibm.mjs';
 import { arbeitsagenturAdapter } from './adapters/arbeitsagentur.mjs';
 import { glintsAdapter } from './adapters/glints.mjs';
 import { jobstreetAdapter } from './adapters/jobstreet.mjs';
-// v1.76.0 — parent career-ops v1.13.0 parity: per-tenant ATS providers.
+// v1.76.0 — per-tenant ATS providers.
 import { bamboohrAdapter } from './adapters/bamboohr.mjs';
 import { breezyAdapter } from './adapters/breezy.mjs';
 import { comeetAdapter } from './adapters/comeet.mjs';
 import { personioAdapter } from './adapters/personio.mjs';
 import { recruiteeAdapter } from './adapters/recruitee.mjs';
 import { solidjobsAdapter } from './adapters/solidjobs.mjs';
-// v1.79.0 — parent career-ops v1.14.0 parity: WeWorkRemotely board-wide RSS feed.
+// v1.79.0 — WeWorkRemotely board-wide RSS feed.
 import { weworkremotelyAdapter } from './adapters/weworkremotely.mjs';
 // v1.80.0 — Teamtailor per-tenant ATS (public /jobs.rss feed).
 import { teamtailorAdapter } from './adapters/teamtailor.mjs';
-// v1.81.0 — parent career-ops origin/main parity: 13 new job-board providers.
+// v1.81.0 — 13 new job-board providers.
 // Board-wide public APIs (provider-selected, fixed endpoint):
 import { thehubAdapter } from './adapters/thehub.mjs';
 import { arbeitnowAdapter } from './adapters/arbeitnow.mjs';
@@ -68,21 +68,21 @@ import { nofluffjobsAdapter } from './adapters/nofluffjobs.mjs';
 // Per-tenant ATS — host-detected from careers_url:
 import { pinpointAdapter } from './adapters/pinpoint.mjs';
 import { ripplingAdapter } from './adapters/rippling.mjs';
-// v1.82.0 — parent career-ops v1.15.0 parity: NoDesk board-wide remote RSS feed.
+// v1.82.0 — NoDesk board-wide remote RSS feed.
 import { nodeskAdapter } from './adapters/nodesk.mjs';
-// v1.87.0 — parent career-ops v1.16.0 parity: 4 new zero-auth providers.
+// v1.87.0 — 4 new zero-auth providers.
 import { getonbrdAdapter } from './adapters/getonbrd.mjs';
 import { amazonAdapter } from './adapters/amazon.mjs';
 import { avatureAdapter } from './adapters/avature.mjs';
 import { successfactorsAdapter } from './adapters/successfactors.mjs';
-// v1.97.0 — parent career-ops parity (#1498): Dassault Systèmes zero-token
+// v1.97.0 — Dassault Systèmes zero-token
 // provider (Exalead card-search XML), single-company, provider-selected.
 import { dassaultAdapter } from './adapters/dassault.mjs';
 import { beesiteAdapter } from './adapters/beesite.mjs';
 import { higheredjobsAdapter } from './adapters/higheredjobs.mjs';
 import { jibeapplyAdapter } from './adapters/jibeapply.mjs';
 import { softgardenAdapter } from './adapters/softgarden.mjs';
-// v1.118.0 — parent career-ops v1.18.0 parity: 9 new providers.
+// v1.118.0 — 9 new providers.
 import { csodAdapter } from './adapters/csod.mjs';
 import { phenomAdapter } from './adapters/phenom.mjs';
 import { radancyAdapter } from './adapters/radancy.mjs';
@@ -92,15 +92,15 @@ import { tkmsAdapter } from './adapters/tkms.mjs';
 import { hecklerkochAdapter } from './adapters/hecklerkoch.mjs';
 import { rheinmetallAdapter } from './adapters/rheinmetall.mjs';
 import { larajobsAdapter } from './adapters/larajobs.mjs';
-// v1.119.0 — parent career-ops v1.19.0 parity: Chinese tech boards, zero-auth
+// v1.119.0 — Chinese tech boards, zero-auth
 // public JSON APIs, host-detected or explicit `provider:`.
 import { meituanAdapter } from './adapters/meituan.mjs';
 import { tencentAdapter } from './adapters/tencent.mjs';
-// v1.123.0 — parent career-ops parity: Oracle Recruiting Cloud (ORC) per-tenant
+// v1.123.0 — Oracle Recruiting Cloud (ORC) per-tenant
 // ATS, zero-auth JSON API, host-detected (*.fa[.<region>][.ocs].oraclecloud.com)
 // or explicit `provider: oraclecloud`.
 import { oraclecloudAdapter } from './adapters/oraclecloud.mjs';
-// v1.124.0 — parent career-ops v1.22.0 parity. wttj + agenticjobs are
+// v1.124.0 — wttj + agenticjobs are
 // board-wide feeds (provider-selected); jobvite + gem are per-tenant ATS
 // (host-detected or explicit `provider:`); alibaba is a single-company
 // careers JSON API (meituan/tencent pattern). All zero-auth.
@@ -109,21 +109,21 @@ import { agenticjobsAdapter } from './adapters/agenticjobs.mjs';
 import { jobviteAdapter } from './adapters/jobvite.mjs';
 import { gemAdapter } from './adapters/gem.mjs';
 import { alibabaAdapter } from './adapters/alibaba.mjs';
-// v1.127.0 — parent career-ops v1.23.0 parity: 3 new sources.
+// v1.127.0 — 3 new sources.
 import { flowxtraAdapter } from './adapters/flowxtra.mjs';
 import { vdabAdapter } from './adapters/vdab.mjs';
 import { icimsAdapter } from './adapters/icims.mjs';
-// v1.130.0 — parent career-ops v1.24.0 parity: 2 new sources.
+// v1.130.0 — 2 new sources.
 import { a16zSpeedrunTalentAdapter } from './adapters/a16z-speedrun-talent.mjs';
 import { cryptocurrencyjobsAdapter } from './adapters/cryptocurrencyjobs.mjs';
 import { manfredAdapter } from './adapters/manfred.mjs';
-// v1.135.0 — parent career-ops v1.26.0 parity: 5 new zero-auth sources.
+// v1.135.0 — 5 new zero-auth sources.
 import { joinAdapter } from './adapters/join.mjs';
 import { joinupAdapter } from './adapters/joinup.mjs';
 import { getroAdapter } from './adapters/getro.mjs';
 import { considerAdapter } from './adapters/consider.mjs';
 import { remotliAdapter } from './adapters/remotli.mjs';
-// v1.136.0 — parent career-ops v1.26.x parity: Eightfold AI boards.
+// v1.136.0 — Eightfold AI boards.
 import { eightfoldAdapter } from './adapters/eightfold.mjs';
 
 export const ALL_ADAPTERS = [
@@ -141,7 +141,7 @@ export const ALL_ADAPTERS = [
   arbeitsagenturAdapter,
   glintsAdapter,
   jobstreetAdapter,
-  // v1.76.0 — parent v1.13.0 parity. Per-tenant ATS detected by careers_url host
+  // v1.76.0 — Per-tenant ATS detected by careers_url host
   // (or explicit `provider:`). Order after the URL-detected ATS above is safe:
   // each matches a distinct host, so resolveAdapter never mis-routes.
   bamboohrAdapter,
@@ -150,12 +150,12 @@ export const ALL_ADAPTERS = [
   personioAdapter,
   recruiteeAdapter,
   solidjobsAdapter,
-  // v1.79.0 — parent v1.14.0 parity. Board-wide remote RSS aggregator,
+  // v1.79.0 — Board-wide remote RSS aggregator,
   // provider-selected (like RemoteOK / Remotive / Working Nomads).
   weworkremotelyAdapter,
   // v1.80.0 — per-tenant ATS, auto-detected from a <slug>.teamtailor.com host.
   teamtailorAdapter,
-  // v1.81.0 — parent origin/main parity: 13 new job-board providers.
+  // v1.81.0 — 13 new job-board providers.
   // Board-wide public APIs, provider-selected (like RemoteOK / Remotive):
   thehubAdapter,
   arbeitnowAdapter,
@@ -174,24 +174,24 @@ export const ALL_ADAPTERS = [
   ripplingAdapter,
   // v1.82.0 — board-wide remote RSS feed, provider-selected (like We Work Remotely).
   nodeskAdapter,
-  // v1.87.0 — parent career-ops v1.16.0 parity. getonbrd is a board-wide public
+  // v1.87.0 — getonbrd is a board-wide public
   // JSON:API (provider-selected); amazon / avature / successfactors are per-tenant
   // ATS endpoints (host-detected or explicit `provider:`), all zero-auth.
   getonbrdAdapter,
   amazonAdapter,
   avatureAdapter,
   successfactorsAdapter,
-  // v1.97.0 — parent parity (#1498): Dassault Systèmes, single global Exalead
+  // v1.97.0 — Dassault Systèmes, single global Exalead
   // endpoint, provider-selected (`provider: dassault`) or 3ds.com host-detected.
   dassaultAdapter,
-  // v1.117.0 — parent parity pack: beesite / jibeapply / softgarden are
+  // v1.117.0 — beesite / jibeapply / softgarden are
   // per-tenant ATS endpoints (host-detected or explicit `provider:`);
   // higheredjobs is a board-wide RSS feed (provider-selected). All zero-auth.
   beesiteAdapter,
   higheredjobsAdapter,
   jibeapplyAdapter,
   softgardenAdapter,
-  // v1.118.0 — parent career-ops v1.18.0 parity. csod (Cornerstone) / phenom /
+  // v1.118.0 — csod (Cornerstone) / phenom /
   // are per-tenant ATS (host-detected or explicit `provider:`); radancy is
   // provider-selected only (branded hosts carry no vendor token); deutschebahn /
   // tkms / hecklerkoch / rheinmetall are single-company careers sites
@@ -206,17 +206,17 @@ export const ALL_ADAPTERS = [
   hecklerkochAdapter,
   rheinmetallAdapter,
   larajobsAdapter,
-  // v1.119.0 — parent career-ops v1.19.0 parity. meituan (zhaopin.meituan.com)
+  // v1.119.0 — meituan (zhaopin.meituan.com)
   // and tencent (careers.tencent.com) are single-company Chinese tech boards
   // with public JSON APIs — host-detected or explicit `provider:`, zero-auth,
   // keyword-driven pagination config via the company entry.
   meituanAdapter,
   tencentAdapter,
-  // v1.123.0 — parent career-ops parity: Oracle Recruiting Cloud (ORC).
+  // v1.123.0 — Oracle Recruiting Cloud (ORC).
   // Per-tenant Fusion Candidate Experience host, distinct host pattern, so
   // ordering after the other host-detected ATS is safe.
   oraclecloudAdapter,
-  // v1.124.0 — parent career-ops v1.22.0 parity (see imports above).
+  // v1.124.0 — see imports above.
   wttjAdapter,
   agenticjobsAdapter,
   jobviteAdapter,

--- a/server/lib/prompts.mjs
+++ b/server/lib/prompts.mjs
@@ -71,7 +71,7 @@ export function buildLocaleDirective(lang) {
 
 /**
  * v1.13.0 — Locale-aware scaffolding strings the prompt builders wrap
- * around the parent's English mode templates. Parent files
+ * around the English mode templates. Those files
  * (`modes/<slug>.md`) are read-only per CLAUDE.md hard rule #1, so the
  * raw body stays English. What CAN be localized is the career-ops-ui
  * scaffolding that wraps the body: the "Read these files first" preamble,
@@ -283,7 +283,7 @@ const MODE_ARTIFACT = {
   batch: 'the result',
 };
 
-// SINGLE-SHOT OUTPUT CONTRACT. The parent `modes/<slug>.md` templates are
+// SINGLE-SHOT OUTPUT CONTRACT. The `modes/<slug>.md` templates are
 // written for interactive Claude Code sessions — several (cover, contacto, …)
 // pause to ask the user clarifying questions before producing the artifact.
 // In the web-ui the runner is single-shot: the model's reply is shown verbatim
@@ -404,7 +404,7 @@ export function buildApplyChecklist(url, jd) {
     '',
     '0. Run /career-ops apply in Claude Code with this URL — it will read the form via Playwright.',
     '1. Verify the posting is still live (check footer/navbar vs JD presence).',
-    // v1.117.0 (parent parity — modes/apply.md step 5b): scan for disqualifying
+    // v1.117.0 (modes/apply.md step 5b): scan for disqualifying
     // ("knock-out") questions BEFORE investing in answers, so a visa/degree/
     // salary-floor mismatch surfaces first, not after 40 minutes of form-filling.
     '2. KNOCK-OUT PRE-SCAN: before drafting anything, scan the form/JD for disqualifying questions — visa/work-authorization or sponsorship requirements, hard degree/certification requirements, salary floors/ceilings, on-site/relocation mandates, security clearances. If any conflicts with your profile, flag it as "⚠️ KNOCK-OUT WARNING: <question> — <why it conflicts>" and decide whether to proceed BEFORE filling the rest.',

--- a/server/lib/role-matcher.mjs
+++ b/server/lib/role-matcher.mjs
@@ -1,9 +1,8 @@
 /**
  * role-matcher.mjs — shared fuzzy role-title matching.
  *
- * Ported verbatim from parent career-ops `role-matcher.mjs` (v1.23.0). Decides
- * whether two same-company titles describe the same opening — used by the
- * repost detector (server/lib/detect-reposts.mjs). Pure, no I/O, no deps.
+ * Decides whether two same-company titles describe the same opening — used by
+ * the repost detector (server/lib/detect-reposts.mjs). Pure, no I/O, no deps.
  */
 
 export const SENIORITY_TOKENS = new Set([
@@ -201,7 +200,7 @@ export function roleFuzzyMatch(a, b) {
   const discriminating = overlap.filter((w) => !BASELINE_TOKENS.has(w));
   if (discriminating.length === 0) return false;
 
-  // Parent #1922 (v1.21.0): a generic base title carries no suffix of its own
+  // A generic base title carries no suffix of its own
   // to counterbalance a specialized sibling's extra word, so shared tokens
   // alone can cross the Jaccard threshold even though that extra word is
   // exactly the signal that these are two separately-postable openings

--- a/server/lib/routes/batch.mjs
+++ b/server/lib/routes/batch.mjs
@@ -8,7 +8,7 @@
  *                                          batch/batch-runner.sh
  *   POST /api/batch/merge              → run merge-tracker.mjs, return result
  *
- * The runner script (`batch/batch-runner.sh`) lives in the project.
+ * The runner script (`batch/batch-runner.sh`) lives in the career-ops project, not this repo.
  * We shell out via `bash` so that script can stay shell — the SPA
  * is a thin streaming wrapper.
  */

--- a/server/lib/routes/batch.mjs
+++ b/server/lib/routes/batch.mjs
@@ -8,8 +8,8 @@
  *                                          batch/batch-runner.sh
  *   POST /api/batch/merge              → run merge-tracker.mjs, return result
  *
- * The runner script (`batch/batch-runner.sh`) lives in the parent project.
- * We shell out via `bash` so the parent's script can stay shell — the SPA
+ * The runner script (`batch/batch-runner.sh`) lives in the project.
+ * We shell out via `bash` so that script can stay shell — the SPA
  * is a thin streaming wrapper.
  */
 import { spawn } from 'node:child_process';
@@ -114,7 +114,7 @@ export function registerBatchRoutes(app) {
         args.push('--max-retries', String(n));
       }
     }
-    // v1.31.0 — parent career-ops 1.8.0 batch-runner.sh flags (#504 +
+    // v1.31.0 — batch-runner.sh flags (#504 +
     // --start-from). Same defense-in-depth as --max-retries: UI is the
     // soft contract, the server validates and silently drops bad input.
     // --model: allow only a conservative model-id charset (alnum, dot,

--- a/server/lib/routes/cli-detect.mjs
+++ b/server/lib/routes/cli-detect.mjs
@@ -18,13 +18,12 @@ import { existsSync, statSync, accessSync, constants } from 'node:fs';
 import { join, delimiter } from 'node:path';
 
 // Fixed allowlist: { id, display name, candidate binary basenames }.
-// Roster mirrors the parent's docs/SUPPORTED_CLIS.md (v1.173.0 sync — 10
+// Roster tracks the supported-CLIs list (v1.173.0 sync — 10
 // first-class CLIs incl. Cursor + Hermes, plus Gemini as a legacy wrapper
-// transitioned into Antigravity; the Antigravity binary is `agy` per the
-// parent matrix).
+// transitioned into Antigravity; the Antigravity binary is `agy`).
 const KNOWN = [
   { id: 'claude', name: 'Claude Code', bins: ['claude'] },
-  // v1.127.0 — parent career-ops v1.23.0 re-added Cursor as a first-class host
+  // v1.127.0 — Cursor is a first-class host
   // (#2115: skill entrypoint at .cursor/skills/career-ops/SKILL.md). Cursor
   // ships a `cursor` PATH launcher.
   { id: 'cursor', name: 'Cursor', bins: ['cursor'] },

--- a/server/lib/routes/content.mjs
+++ b/server/lib/routes/content.mjs
@@ -1,5 +1,5 @@
 /**
- * Content routes — read/write of the project's text artifacts:
+ * Content routes — read/write of the career-ops project's text artifacts:
  *   GET  /api/cv          → { markdown }
  *   PUT  /api/cv          → save (sanitized) markdown
  *   POST /api/cv/import   → convert uploaded docx/pdf/html/… to markdown

--- a/server/lib/routes/content.mjs
+++ b/server/lib/routes/content.mjs
@@ -1,5 +1,5 @@
 /**
- * Content routes — read/write of the parent project's text artifacts:
+ * Content routes — read/write of the project's text artifacts:
  *   GET  /api/cv          → { markdown }
  *   PUT  /api/cv          → save (sanitized) markdown
  *   POST /api/cv/import   → convert uploaded docx/pdf/html/… to markdown

--- a/server/lib/routes/cv-studio.mjs
+++ b/server/lib/routes/cv-studio.mjs
@@ -235,7 +235,7 @@ export function registerCvStudioRoutes(app) {
     return res.json({ mode: r.mode, prompt, markdown: cleanLlmMarkdown(r.markdown), usage: r.usage });
   });
 
-  // v1.117.0 (parent parity — modes/add.md, generalized) — "Add to CV".
+  // v1.117.0 (modes/add.md, generalized) — "Add to CV".
   // Turn a source (a GitHub repo / article / portfolio URL, or pasted text)
   // into ATS-ready CV bullet points GROUNDED ONLY in that source. The model is
   // forbidden from inventing metrics, employers, or dates — anything not in

--- a/server/lib/routes/followup.mjs
+++ b/server/lib/routes/followup.mjs
@@ -1,19 +1,19 @@
 /**
- * Follow-up cadence routes (v1.117.0) — parent parity.
+ * Follow-up cadence routes (v1.117.0).
  *
- * The parent career-ops ships a full follow-up cadence engine
+ * A companion CLI ships a full follow-up cadence engine
  * (`followup-cadence.mjs` — parses applications.md + follow-ups.md, computes
  * per-application urgency: urgent / overdue / waiting / cold — and
  * `followup-seed.mjs` — pins a first follow-up date when a row turns Applied).
  * web-ui only had the LLM `followup` mode page; the deterministic cadence data
- * was never surfaced. These routes SHELL OUT to the parent scripts (the same
+ * was never surfaced. These routes SHELL OUT to those scripts (the same
  * pattern as the doctor/verify/dedup runners) instead of reimplementing the
- * cadence math — the parent stays the single source of truth and web-ui can't
- * drift from it.
+ * cadence math — those scripts stay the single source of truth and web-ui can't
+ * drift from them.
  *
  *   GET  /api/followup       → run `followup-cadence.mjs` (JSON stdout) and
  *                              relay { available:true, metadata, entries,
- *                              cadenceConfig }. If the parent script is absent
+ *                              cadenceConfig }. If the script is absent
  *                              (CI, standalone installs) → { available:false }.
  *   POST /api/followup/seed  → explicit user action. Body {appNum} seeds one
  *                              application, {backfill:true} seeds the whole
@@ -47,12 +47,12 @@ export function registerFollowupRoutes(app) {
     }
     const r = await runNodeScript(CADENCE_SCRIPT, [], { timeoutMs: RUN_TIMEOUT_MS });
     const data = parseJsonStdout(r.stdout);
-    // The parent exits 1 with a STRUCTURED {error} on stdout for "no data yet"
+    // The script exits 1 with a STRUCTURED {error} on stdout for "no data yet"
     // (e.g. an empty tracker). That is a healthy empty state, not a failure —
     // relay it as available with zero entries so the board shows its honest
-    // empty message instead of "script-error". Keyed to the parent's exact
+    // empty message instead of "script-error". Keyed to the script's exact
     // message (followup-cadence.mjs), NOT to shape — an unrecognized {error}
-    // must fall through to the honest script-error path, or a future parent
+    // must fall through to the honest script-error path, or a future script
     // regression would be silently masked as "nothing yet".
     if (data && isEmptyTrackerError(data.error)) {
       res.json({ available: true, empty: true, note: data.error, metadata: {}, entries: [] });

--- a/server/lib/routes/funded.mjs
+++ b/server/lib/routes/funded.mjs
@@ -1,22 +1,22 @@
 /**
- * Funded-company discovery relay (v1.133.0, parent parity #2117).
+ * Funded-company discovery relay (v1.133.0).
  *
- * Shells out to the parent's `company-funded.mjs` — a review-first discovery
+ * Shells out to the `company-funded.mjs` script — a review-first discovery
  * script that reads a FIXED set of public, host-pinned RSS/JSON feeds
  * (TechCrunch / PRNewswire / Guardian / Hacker News), extracts recently
  * funded companies, and returns a ranked candidate list for MANUAL review.
- * The parent script owns the feed list, the host-pinning/SSRF guards, and the
+ * That script owns the feed list, the host-pinning/SSRF guards, and the
  * funding-signal parsing — web-ui relays its JSON so it can't drift.
  *
  *   GET /api/company-funded → { available, generatedAt, sources, candidates[], diagnostics[] }
  *
  * Read-only contract:
- *   • `--dry-run` — the parent writes report/JSON artifacts ONLY when NOT
+ *   • `--dry-run` — the script writes report/JSON artifacts ONLY when NOT
  *     dry-run, so this relay never persists anything.
  *   • `--json`    — machine-readable JSON to stdout.
  *   • We deliberately do NOT thread any request input into `--sources`: the
- *     source set stays the parent's fixed defaults, so no user-supplied value
- *     ever reaches an outbound fetch (no SSRF surface beyond the parent's own
+ *     source set stays the script's fixed defaults, so no user-supplied value
+ *     ever reaches an outbound fetch (no SSRF surface beyond the script's own
  *     host-pinned feeds).
  * Live network fetch (several RSS feeds) → a generous timeout + `llmRateLimit`;
  * the client panel is user-triggered (a Discover button), never on mount.

--- a/server/lib/routes/health.mjs
+++ b/server/lib/routes/health.mjs
@@ -9,7 +9,7 @@
  * exact Node versions are replaced with "hidden" to reduce LAN
  * fingerprinting.
  *
- * /api/dashboard aggregates from the parent's applications + pipeline +
+ * /api/dashboard aggregates from the applications + pipeline +
  * reports trees via the defensive store helpers.
  */
 import { readFileSync, existsSync } from 'node:fs';
@@ -65,7 +65,7 @@ export function registerHealthRoutes(app) {
     checks.push({ name: 'ANTHROPIC_API_KEY', required: false, ok: anthropicSet, value: anthropicSet ? 'set' : 'unset (set to enable live "Run" buttons)' });
     // v1.58.8 — every headless live-eval provider gets a row on `#/health`,
     // mirroring the GEMINI/ANTHROPIC pattern. Same `isUsableKey` gate as
-    // /api/status/providers so a placeholder in the parent `.env` is never
+    // /api/status/providers so a placeholder in the `.env` is never
     // reported "set" here. "manual mode" copy matches GEMINI's wording —
     // any provider unset just falls back to the prompt-generation flow.
     checks.push({ name: 'OPENAI_API_KEY',     required: false, ok: openaiSet,     value: openaiSet     ? 'set' : 'unset (manual mode)' });
@@ -108,7 +108,7 @@ export function registerHealthRoutes(app) {
       version = pkg.version || '?';
     } catch {}
     try {
-      // The parent VERSION file may carry a release-please inline comment
+      // The VERSION file may carry a release-please inline comment
       // ("1.15.0 # x-release-please-version") — surface just the semver.
       const raw = readFileSync(PATHS.version, 'utf8').trim();
       parentVersion = (raw.match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/) || [raw])[0];

--- a/server/lib/routes/interview.mjs
+++ b/server/lib/routes/interview.mjs
@@ -224,12 +224,12 @@ export function registerInterviewRoutes(app) {
     res.json({ ok: true, deleted: safe });
   });
 
-  // v1.133.0 (parent parity #2129/#2130) — Weekly Interview Digest.
-  // Shells out to the parent's zero-LLM `weekly-digest.mjs` (JSON stdout:
+  // v1.133.0 — Weekly Interview Digest.
+  // Shells out to the zero-LLM `weekly-digest.mjs` script (JSON stdout:
   // a mechanical roll-up of `interview-prep/sessions/*.md` — which companies
   // you interviewed with this week, rounds, recurring competencies, and
   // best-effort open gaps from question-bank.md) instead of reimplementing
-  // the session-schema parser — the parent stays the source of truth. An
+  // the session-schema parser — that script stays the source of truth. An
   // empty range is a valid `available:true` digest with empty arrays (NOT a
   // failure). Read-only; fail-soft { available:false } when the script is
   // absent (CI, standalone installs) so the panel shows an honest note.
@@ -240,7 +240,7 @@ export function registerInterviewRoutes(app) {
       return;
     }
     // Optional range: pass --from/--to ONLY when BOTH are valid YYYY-MM-DD
-    // (the parent script rejects exactly one of the pair); otherwise fall
+    // (the script rejects exactly one of the pair); otherwise fall
     // through to its default current-week range.
     const from = String(req.query.from || '');
     const to = String(req.query.to || '');

--- a/server/lib/routes/llm.mjs
+++ b/server/lib/routes/llm.mjs
@@ -169,7 +169,7 @@ export function registerLlmRoutes(app) {
 
     if (_provGate().wantGemini && hasGeminiKey()) {
       // Use the existing gemini-eval.mjs pipe interface — it reads the
-      // CV from disk itself (it's a Node script in the parent), so no
+      // CV from disk itself (it's a standalone Node script), so no
       // bundleProjectContext needed here.
       const tmpFile = projPath('output', `web-jd-${Date.now()}.txt`);
       mkdirSync(PATHS.outputDir, { recursive: true });

--- a/server/lib/routes/logos.mjs
+++ b/server/lib/routes/logos.mjs
@@ -8,7 +8,7 @@
  * third-party logo aggregator — so no new party learns which employers you
  * look at. The fetch goes through the DNS-pinned, SSRF-safe `safeGet` (binary
  * mode), is size-capped and time-bounded, and results are cached in memory
- * (never written to disk — this is a viewer over the parent project). Off by
+ * (never written to disk — this is a read-only viewer). Off by
  * default; the client only calls this when the user enables company logos.
  */
 import { safeGet } from '../safe-fetch.mjs';

--- a/server/lib/routes/portals.mjs
+++ b/server/lib/routes/portals.mjs
@@ -1,7 +1,7 @@
 /**
  * Portals health routes (v1.99.0).
  *
- * The scanner watches a set of companies declared in the parent's `portals.yml`
+ * The scanner watches a set of companies declared in `portals.yml`
  * (`tracked_companies:`). An ATS slug can quietly break — a company renames its
  * board or moves off Greenhouse — and then that employer silently vanishes from
  * every future scan with no error. This surfaces that: list the watched

--- a/server/lib/routes/runners.mjs
+++ b/server/lib/routes/runners.mjs
@@ -88,7 +88,7 @@ const BUFFERED = [
   { route: '/api/run/dedup',      script: 'dedup-tracker.mjs' },
   { route: '/api/run/merge',      script: 'merge-tracker.mjs' },
   { route: '/api/run/sync-check', script: 'cv-sync-check.mjs' },
-  // v1.117.0 (parent parity) — sync pipeline.md "Pendientes" with batch-state.tsv
+  // v1.117.0 — sync pipeline.md "Pendientes" with batch-state.tsv
   { route: '/api/run/reconcile',  script: 'reconcile-pipeline.mjs' },
 ];
 
@@ -102,7 +102,7 @@ export function registerRunnerRoutes(app) {
 
   // v1.12.0 — renamed from `/api/stream/scan` to `/api/stream/scan-parent`
   // so the namespace is free for the consolidated in-process scanner
-  // (F-018 LITE) registered in `routes/scan.mjs`. The parent-spawned
+  // (F-018 LITE) registered in `routes/scan.mjs`. The spawned
   // scan.mjs runner stays available for the kitchen-sink fallback.
   app.get('/api/stream/scan-parent', (req, res) => {
     const args = [];

--- a/server/lib/routes/scan.mjs
+++ b/server/lib/routes/scan.mjs
@@ -13,7 +13,7 @@
  * event names are unchanged.
  *
  * NOTE: the buffered `scan.mjs` runner (POST /api/run/scan) lives in the
- * runners table inside index.mjs; it spawns the parent's scan.mjs and is
+ * runners table inside index.mjs; it spawns the standalone scan.mjs and is
  * unrelated to these in-process routes.
  */
 import { runRuScan, loadConfig as loadRuConfig } from '../ru-scanner.mjs';

--- a/server/lib/routes/stats.mjs
+++ b/server/lib/routes/stats.mjs
@@ -89,11 +89,11 @@ export function registerStatsRoutes(app) {
     res.json({ snapshots });
   });
 
-  // v1.117.0 (parent parity) — rejection-pattern / ATS-channel analytics.
-  // Shells out to the parent's `analyze-patterns.mjs` (JSON stdout: outcome
+  // v1.117.0 — rejection-pattern / ATS-channel analytics.
+  // Shells out to the `analyze-patterns.mjs` script (JSON stdout: outcome
   // classification per archetype / seniority / remote / score band, plus the
   // per-ATS-vendor advance rate motivated by Bommasani et al., FAccT 2026)
-  // instead of reimplementing it — the parent stays the source of truth and
+  // instead of reimplementing it — that script stays the source of truth and
   // web-ui cannot drift. Read-only; fail-soft { available:false } when the
   // script is absent (CI, standalone installs) so the tab shows an honest note.
   app.get('/api/stats/patterns', llmRateLimit, async (_req, res) => {
@@ -106,7 +106,7 @@ export function registerStatsRoutes(app) {
     const data = parseJsonStdout(r.stdout);
     // Structured {error} on stdout = a healthy "no data yet" answer (empty
     // tracker), not a failure — relay as available with empty sections so the
-    // tab renders its honest empty state. Keyed to the parent's exact
+    // tab renders its honest empty state. Keyed to the script's exact
     // messages (analyze-patterns.mjs) via isEmptyTrackerError; any OTHER
     // {error} falls through to the honest script-error path below.
     if (data && isEmptyTrackerError(data.error)) {
@@ -124,13 +124,13 @@ export function registerStatsRoutes(app) {
     res.json({ available: true, ...data });
   });
 
-  // v1.118.0 (parent v1.18.0 parity) — lifetime pipeline stats (#1605).
-  // Shells out to the parent's `stats.mjs` (zero-token aggregator: tracker
+  // v1.118.0 — lifetime pipeline stats (#1605).
+  // Shells out to the `stats.mjs` script (zero-token aggregator: tracker
   // roll-up, cumulative funnel, lifetime scanner totals, portal coverage,
   // follow-up compliance). The script degrades sections to null itself when a
   // source file is missing and reports what it found in `metadata.sources`,
   // so a fresh install still relays a full contract shape. Read-only;
-  // fail-soft { available:false } without the parent script.
+  // fail-soft { available:false } without the script.
   app.get('/api/stats/lifetime', llmRateLimit, async (_req, res) => {
     const script = 'stats.mjs';
     if (!existsSync(resolve(PROJECT_ROOT, script))) {
@@ -150,10 +150,10 @@ export function registerStatsRoutes(app) {
     res.json({ available: true, ...data });
   });
 
-  // v1.118.0 (parent v1.18.0 parity) — compensation observations (salary-gap.mjs).
+  // v1.118.0 — compensation observations (salary-gap.mjs).
   // Desired vs advertised vs actual comp, folded from reports' Machine Summary,
   // data/salary-observations.tsv and profile target range. Same relay contract
-  // as /api/stats/lifetime: read-only, fail-soft without the parent script.
+  // as /api/stats/lifetime: read-only, fail-soft without the script.
   app.get('/api/stats/salary-gap', llmRateLimit, async (_req, res) => {
     const script = 'salary-gap.mjs';
     if (!existsSync(resolve(PROJECT_ROOT, script))) {

--- a/server/lib/routes/tracker.mjs
+++ b/server/lib/routes/tracker.mjs
@@ -16,11 +16,11 @@ import { safeReadApps } from '../store.mjs';
 import { withFileLock } from '../file-lock.mjs';
 import { canonicalizeStatus, readCanonicalStates } from '../states.mjs';
 
-// v1.128.0 (parent web/ port #2) — the canonical status vocabulary is no
-// longer hardcoded here. `server/lib/states.mjs` reads the parent's
+// v1.128.0 — the canonical status vocabulary is no
+// longer hardcoded here. `server/lib/states.mjs` reads
 // `templates/states.yml` live (id/label/aliases), so the whitelist — and
-// alias folding (Spanish/legacy labels the parent writer may emit) — stays in
-// sync with the parent automatically instead of needing a manual re-sync every
+// alias folding (Spanish/legacy labels the writer may emit) — stays in
+// sync with the states file automatically instead of needing a manual re-sync every
 // release (the v1.118.0 'Hired' addition was one such sweep).
 
 export function registerTrackerRoutes(app) {
@@ -37,8 +37,8 @@ export function registerTrackerRoutes(app) {
     if (page === undefined && pageSize === undefined && status === undefined) {
       return res.json({ rows: all }); // legacy shape — untouched
     }
-    // Fold each raw status to its canonical bucket (parent web/ port #3) so a
-    // Spanish/legacy label the parent writer may emit (e.g. "contratada",
+    // Fold each raw status to its canonical bucket so a
+    // Spanish/legacy label the writer may emit (e.g. "contratada",
     // "**Applied**") lands in the same bucket as its canonical form instead of
     // spawning a phantom funnel entry. Unknown labels keep their raw value.
     const funnel = {};
@@ -56,7 +56,7 @@ export function registerTrackerRoutes(app) {
     res.json({ rows, total, page: pg, pageSize: ps, funnel });
   });
 
-  // v1.131.0 — the #/tracker CRM stage-tab board (parent web/ `/pipeline` port)
+  // v1.131.0 — the #/tracker CRM stage-tab board
   // needs the FULL canonical funnel — labels in order, including zero-count
   // stages — plus an alias-fold map, so the client can bucket rows without ever
   // hardcoding the whitelist (the v1.128.0 doctrine). Read-only, no writes, no

--- a/server/lib/ru-scanner.mjs
+++ b/server/lib/ru-scanner.mjs
@@ -102,8 +102,8 @@ export function loadConfig() {
     area: ru.area ?? 113, // Russia
     perPage: ru.per_page ?? 50,
     onlyRemote: ru.only_remote ?? false,
-    // v1.33.0 (WS4 / parent #570) — optional portals.yml location_filter.
-    // Top-level key (same as parent scan.mjs), not under russian_portals.
+    // v1.33.0 (WS4) — optional portals.yml location_filter.
+    // Top-level key, not under russian_portals.
     locationFilter: portals.location_filter || null,
     // v1.75.0 (#974) — optional content_filter (top-level key, like parent).
     contentFilter: portals.content_filter || null,
@@ -251,7 +251,7 @@ export async function runRuScan(opts = {}) {
   for (const j of allFound) uniq.set(j.url, j);
   const flat = [...uniq.values()];
 
-  // Apply negative-filter + location-filter (parent #570 parity),
+  // Apply negative-filter + location-filter,
   // then stamp boost flags. Boost is informational only — it doesn't
   // change which rows are returned, only marks the boosted ones so the
   // SPA can render a "⬆ boosted" badge on them.
@@ -263,7 +263,7 @@ export async function runRuScan(opts = {}) {
     && locOk(j.location)
     && contentOk(j.description ?? j.snippet));
   let filtered = applyBoostStamps(filteredRaw, cfg.boosts);
-  // v1.76.0 — optional trust annotation (parent career-ops v1.13.0). Off unless
+  // v1.76.0 — optional trust annotation. Off unless
   // `trust_filter:` is present and not disabled. Never drops a job.
   if (cfg.trustFilter && cfg.trustFilter.enabled !== false) {
     const trust = buildTrustValidator(cfg.trustFilter);

--- a/server/lib/scan-sanitize.mjs
+++ b/server/lib/scan-sanitize.mjs
@@ -1,5 +1,5 @@
 /**
- * Scan-write sanitizers (v1.75.0 — parent career-ops v1.12.0 #1098 parity).
+ * Scan-write sanitizers (v1.75.0).
  *
  * Job postings come from external feeds (Greenhouse, RemoteOK, Glints, …).
  * Their title / company / location strings are attacker-influenced data that
@@ -10,11 +10,10 @@
  *
  * Without sanitization a posting whose company name contains a newline could
  * inject a whole extra TSV row, and a value beginning with `= + - @` becomes a
- * live formula when the TSV is opened in a spreadsheet. These helpers follow
- * the parent's scan.mjs sanitizers; the control-character class is a strict
- * superset of the parent's (`\r\n\t` plus the vertical tab, form feed, and the
- * Unicode line/paragraph separators), so any record/line separator a viewer
- * might honor is collapsed — never weaker than the parent.
+ * live formula when the TSV is opened in a spreadsheet. The control-character
+ * class here is deliberately broad (`\r\n\t` plus the vertical tab, form feed,
+ * and the Unicode line/paragraph separators), so any record/line separator a
+ * viewer might honor is collapsed.
  */
 
 // Record/line/column separators (and their close cousins) that must never

--- a/server/lib/sources/a16z-speedrun-talent.mjs
+++ b/server/lib/sources/a16z-speedrun-talent.mjs
@@ -54,8 +54,8 @@ const DEFAULT_MAX_PAGES = 6; // × PER_PAGE = the 300-job default scan (sized in
 // Runaway bound, not a coverage target: iteration already stops at the feed's
 // reported total_pages (or a short page), so on an honest feed the cap costs
 // nothing and full-board sweeps keep working as the board grows. It only bites a
-// misbehaving feed or an absurd max_pages entry (~353 pages /
-// ~17.6k jobs as of 2026-08), same policy as workday's cap.
+// misbehaving feed or an absurd max_pages entry; the board was ~353 pages /
+// ~17.6k jobs as of 2026-08, same policy as workday's cap.
 const MAX_PAGES_CAP = 1000; // hard stop on request count regardless of max_pages
 const PAGE_DELAY_MS = 0; // no documented rate limit; tunable via opts
 

--- a/server/lib/sources/a16z-speedrun-talent.mjs
+++ b/server/lib/sources/a16z-speedrun-talent.mjs
@@ -1,8 +1,7 @@
 // @ts-check
 /**
- * a16z Speedrun talent-network source — board-wide, zero-auth JSON aggregator
- * (parity with parent career-ops `providers/a16z-speedrun-talent.mjs`). Covers
- * the a16z speedrun cohort plus the wider a16z portfolio (~200 startups).
+ * a16z Speedrun talent-network source — board-wide, zero-auth JSON aggregator.
+ * Covers the a16z speedrun cohort plus the wider a16z portfolio (~200 startups).
  *
  *   GET https://speedrun-talent-network.com/api/v1/jobs?page={n}&source=career-ops
  *   → { jobs: [ { id, title, company, url, location, remote, published_at, … } ],
@@ -50,15 +49,15 @@ export const SPEEDRUN_TALENT_HOST_RE = /^speedrun-talent-network\.com$/i;
 /** Canonical API listing URL (adapter default endpoint). */
 export const FEED_URL = `${SITE_ORIGIN}/api/v1/jobs`;
 
-const PER_PAGE = 50; // feed page size — the API caps a page at 50; PER_PAGE=100 made the `rawCount < PER_PAGE` guard stop after page 1, truncating to 50 jobs (parent #2404)
-const DEFAULT_MAX_PAGES = 6; // × PER_PAGE = the 300-job default scan (parent #36d0c44 — sized in 50-job pages)
+const PER_PAGE = 50; // feed page size — the API caps a page at 50; PER_PAGE=100 made the `rawCount < PER_PAGE` guard stop after page 1, truncating to 50 jobs
+const DEFAULT_MAX_PAGES = 6; // × PER_PAGE = the 300-job default scan (sized in 50-job pages)
 // Runaway bound, not a coverage target: iteration already stops at the feed's
 // reported total_pages (or a short page), so on an honest feed the cap costs
 // nothing and full-board sweeps keep working as the board grows. It only bites a
-// misbehaving feed or an absurd max_pages entry (parent #36d0c44: ~353 pages /
+// misbehaving feed or an absurd max_pages entry (~353 pages /
 // ~17.6k jobs as of 2026-08), same policy as workday's cap.
 const MAX_PAGES_CAP = 1000; // hard stop on request count regardless of max_pages
-const PAGE_DELAY_MS = 0; // no documented rate limit (parent parity); tunable via opts
+const PAGE_DELAY_MS = 0; // no documented rate limit; tunable via opts
 
 /** Upper bound on jobs returned across all pages — bounds memory defensively. */
 export const MAX_RESULTS = MAX_PAGES_CAP * PER_PAGE;
@@ -248,7 +247,7 @@ export async function fetchSpeedrunTalent(feedUrl = FEED_URL, opts = {}) {
     try {
       // This board paginates into the hundreds of pages, so a single transient
       // upstream blip mid-sweep used to abort the whole provider and return
-      // NOTHING (parent #2506). Retry transient failures (429/5xx/timeout);
+      // NOTHING. Retry transient failures (429/5xx/timeout);
       // a permanent 4xx is not retried. Once retries are exhausted the error
       // propagates here and the page-0-throw / later-page-keep-partials rule
       // below decides the outcome (web-ui dead-board contract).
@@ -287,7 +286,7 @@ export async function fetchSpeedrunTalent(feedUrl = FEED_URL, opts = {}) {
     if (rawCount < PER_PAGE) break;
     if (Number.isInteger(json.total_pages) && page + 1 >= json.total_pages) break;
     // Cap warning: the feed had more pages than we were allowed to read — surface
-    // it with the fix (same pattern as parent jibeapply/workday).
+    // it with the fix (same pattern as jibeapply/workday).
     if (page + 1 >= maxPages && Number.isInteger(json.total_pages) && json.total_pages > maxPages) {
       const name = fallbackCompany || 'a16z speedrun talent network';
       console.error(

--- a/server/lib/sources/a16z-speedrun-talent.mjs
+++ b/server/lib/sources/a16z-speedrun-talent.mjs
@@ -54,8 +54,8 @@ const DEFAULT_MAX_PAGES = 6; // × PER_PAGE = the 300-job default scan (sized in
 // Runaway bound, not a coverage target: iteration already stops at the feed's
 // reported total_pages (or a short page), so on an honest feed the cap costs
 // nothing and full-board sweeps keep working as the board grows. It only bites a
-// misbehaving feed or an absurd max_pages entry; the board was ~353 pages /
-// ~17.6k jobs as of 2026-08, same policy as workday's cap.
+// misbehaving feed or an absurd max_pages entry. (The board itself was ~353
+// pages / ~17.6k jobs as of 2026-08.) Same headroom policy as workday's cap.
 const MAX_PAGES_CAP = 1000; // hard stop on request count regardless of max_pages
 const PAGE_DELAY_MS = 0; // no documented rate limit; tunable via opts
 

--- a/server/lib/sources/agenticjobs.mjs
+++ b/server/lib/sources/agenticjobs.mjs
@@ -1,7 +1,6 @@
 // @ts-check
 /**
- * Agentic Jobs source — the site's public, documented REST API (parity with
- * parent career-ops `providers/agentic-jobs.mjs`, #2143/#2167).
+ * Agentic Jobs source — the site's public, documented REST API.
  *
  *   GET {API_BASE}/jobs?page={n}   — 1-based paging, PAGE_SIZE per page
  *   → { data: [{ title, companyName|company, slug|url, location,

--- a/server/lib/sources/alibaba.mjs
+++ b/server/lib/sources/alibaba.mjs
@@ -2,7 +2,7 @@
  * Alibaba Group careers source — posts to the public talent.alibaba.com JSON
  * API (no auth, no login, no browser).
  *
- * Ported from parent career-ops `providers/alibaba.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract. Alibaba is a single-company board, so it is selected via an
  * explicit `provider: alibaba` entry or auto-detected from a talent.alibaba.com
  * careers_url. Config comes from the company entry, read via `opts.company`:

--- a/server/lib/sources/amazon.mjs
+++ b/server/lib/sources/amazon.mjs
@@ -3,7 +3,7 @@
  * Amazon / AWS source — the public amazon.jobs search JSON API
  *   GET https://www.amazon.jobs/en/search.json?base_query=&loc_query=&result_limit=100&offset=0
  *
- * Ported from parent career-ops `providers/amazon.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). Public, zero-auth
  * JSON. The board is enormous (100k+ postings), so a per-company `amazon:` config
  * block (loc_query / base_query / category …) narrows it; keys pass through as

--- a/server/lib/sources/arbeitnow.mjs
+++ b/server/lib/sources/arbeitnow.mjs
@@ -2,7 +2,7 @@
  * Arbeitnow source — board-wide aggregator feed (EU/DACH-heavy, international).
  *   GET https://www.arbeitnow.com/api/job-board-api  → { data: [...], links, meta }
  *
- * Ported from parent career-ops `providers/arbeitnow.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery).
  *
  * The full board is fetched (single page of the public feed) so the en-scanner's

--- a/server/lib/sources/arbeitsagentur.mjs
+++ b/server/lib/sources/arbeitsagentur.mjs
@@ -4,7 +4,7 @@
  * keywords (recall-first); the en-scanner applies title_filter + location_filter
  * + dedup afterwards.
  *
- * Ported from parent career-ops `providers/arbeitsagentur.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. Config comes from the company entry's `arbeitsagentur:`
  * block, read via `opts.company`:
  *
@@ -74,7 +74,7 @@ export function parseArbeitsagenturConfig(entry) {
     days: intInRange(cfg.days, 30, 1, 1000),
     size: intInRange(cfg.size, 100, 1, 100),
     remoteNationwide: cfg.remoteNationwide === true,
-    // v1.76.0 — config-driven remote detection (parent career-ops v1.13.0 #1189).
+    // v1.76.0 — config-driven remote detection.
     remoteMatch: ['title', 'filter', 'off'].includes(cfg.remoteMatch) ? cfg.remoteMatch : 'title',
     remoteMaxPages: intInRange(cfg.remoteMaxPages, 1, 1, 20),
   };

--- a/server/lib/sources/ashby.mjs
+++ b/server/lib/sources/ashby.mjs
@@ -26,7 +26,7 @@ export async function fetchAshby(apiUrl, opts = {}) {
   return (data.jobs || []).map((j) => normalize(j));
 }
 
-// v1.75.0 (parent #1073) — build the full location from primary +
+// v1.75.0 — build the full location from primary +
 // secondaryLocations. Ashby puts extra hiring regions in `secondaryLocations[]`
 // (each with a region label and a postalAddress). Using only `j.location` drops
 // them, so an EU-eligible role whose PRIMARY label is e.g. "Canada" reads as

--- a/server/lib/sources/avature.mjs
+++ b/server/lib/sources/avature.mjs
@@ -7,7 +7,7 @@
  * proxies Avature), so there is no single canonical endpoint — the URL comes
  * from the company entry's `api:` / `careers_url` and is host-pinned to it.
  *
- * Ported from parent career-ops `providers/avature.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). The list page is a
  * server-rendered document of `<article class="article article--result">`
  * blocks; each carries an `<a class="link" href=".../JobDetail/...">` title
@@ -105,7 +105,6 @@ export function parseAvature(html, ctx = /** @type {any} */ ({})) {
   const out = [];
   // Tenants vary the result class: Synopsys uses `article--result`, Siemens
   // appends a position index (`article--result 1`). Accept any suffix.
-  // (parent career-ops parity, #1541)
   const re = /<article class="article article--result[^"]*"[\s\S]*?<\/article>/g;
   let a;
   while ((a = re.exec(html)) !== null) {

--- a/server/lib/sources/bamboohr.mjs
+++ b/server/lib/sources/bamboohr.mjs
@@ -3,7 +3,7 @@
  * BambooHR source — hits the public per-tenant careers list API.
  *   GET https://<tenant>.bamboohr.com/careers/list
  *
- * Ported from parent career-ops v1.13.0 `providers/bamboohr.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. Per-tenant subdomains are the variable part, so the SSRF
  * defence is an anchored host regex (same approach as breezy/personio) plus
  * `redirect:'error'` — a server-side redirect can't bounce the fetch off-domain.

--- a/server/lib/sources/beesite.mjs
+++ b/server/lib/sources/beesite.mjs
@@ -11,12 +11,12 @@
  *          "PositionLocation":[{"CityName":"Bremen"}],
  *          "PublicationStartDate":"2026-07-04"}}]}}
  *
- * Ported from parent career-ops `providers/beesite.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta`). PositionURI is the BRANDED job page,
  * so listings link straight to the public posting. FirstItem is 1-based;
  * requesting past the end returns an empty list; newest-first sort keeps a
- * bounded walk on the most recent postings. Safety caps preserved from the
- * parent: MAX_PAGES=40 (page size 100), MAX_JOBS=1000. Host-pinned to
+ * bounded walk on the most recent postings. Safety caps: MAX_PAGES=40 (page
+ * size 100), MAX_JOBS=1000. Host-pinned to
  * *.beesite.de + `redirect:'error'` (SSRF-safe).
  *
  * Per-tenant: the endpoint origin comes from the company entry's `api:` /
@@ -138,7 +138,7 @@ function resolveMaxPages(company) {
 }
 
 /**
- * Fetch + parse a tenant's postings with the parent's bounded newest-first
+ * Fetch + parse a tenant's postings with a bounded newest-first
  * walk. `endpoint` is the tenant /search API from the adapter's buildEndpoint;
  * pagination stops on an empty page, a no-fresh-rows page, MAX_JOBS, or total.
  */

--- a/server/lib/sources/breezy.mjs
+++ b/server/lib/sources/breezy.mjs
@@ -3,7 +3,7 @@
  * Breezy HR source — hits the public per-tenant board feed.
  *   GET https://<tenant>.breezy.hr/json
  *
- * Ported from parent career-ops v1.13.0 `providers/breezy.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. Per-tenant subdomains vary, so the SSRF defence is an
  * anchored host regex (same approach as bamboohr/personio) plus `redirect:'error'`.
  * Only the public board feed is used; the authenticated REST API is never touched.

--- a/server/lib/sources/comeet.mjs
+++ b/server/lib/sources/comeet.mjs
@@ -3,7 +3,7 @@
  * Comeet (Spark Hire Recruit) source — hits the public, no-auth careers API.
  *   GET https://www.comeet.co/careers-api/2.0/company/<uid>/positions?token=<token>
  *
- * Ported from parent career-ops v1.13.0 `providers/comeet.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. Neither the company-uid nor the per-tenant token is derivable
  * from a branded careers URL, so the full API URL must be supplied via `api:`.
  * The API host is a single fixed origin, so the SSRF defence pins hostname to

--- a/server/lib/sources/consider.mjs
+++ b/server/lib/sources/consider.mjs
@@ -3,7 +3,7 @@
  * Consider source — VC "talent network" portfolio boards on getconsider.com
  * (Founderful, Creandum, Balderton, Lightspeed, Notion Capital, …).
  *
- * Ported from parent career-ops `providers/consider.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). The board is a JS
  * app, but its data comes from a same-origin JSON endpoint we hit directly:
  *
@@ -74,8 +74,7 @@ export function toEpochMs(value) {
  * non-HTTPS, IPv4/IPv6 literals, localhost, *.local, *.internal, and
  * single-label (non-public) hosts so a malicious or misconfigured careers_url
  * can't aim the POST at an internal target (127.0.0.1, 169.254.169.254
- * cloud-metadata, ::1, localhost, *.internal). Ported EXACTLY from the parent
- * provider's `resolveOrigin`. Exported for tests.
+ * cloud-metadata, ::1, localhost, *.internal). Exported for tests.
  * @param {{ careers_url?: string }} entry
  * @returns {string|null} the public https origin, or null when unsafe
  */

--- a/server/lib/sources/cryptocurrencyjobs.mjs
+++ b/server/lib/sources/cryptocurrencyjobs.mjs
@@ -3,7 +3,7 @@
  * Cryptocurrency Jobs source — curated Web3/crypto job board, board-wide RSS.
  *   GET https://cryptocurrencyjobs.co/index.xml
  *
- * Ported from parent career-ops `providers/cryptocurrencyjobs.mjs` into the
+ * Implements the
  * web-ui source contract (rich job objects + `meta` for auto-discovery).
  *
  * The feed is public, no-auth RSS 2.0, parsed in-process with a tiny tag
@@ -61,16 +61,14 @@ function toIsoDate(value) {
 // This feed's generator double-encodes entities at the source (verified live:
 // the raw XML carries e.g. `Social Media &amp;amp; Growth Lead`), so a single
 // canonical pass leaves a stray `&amp;` in some titles. Exactly TWO passes —
-// NOT a decode-until-stable loop, which is the js/double-escaping bug class the
-// parent explicitly avoids — normalizes this feed's shape and stays
-// deterministic. Ported faithfully from providers/cryptocurrencyjobs.mjs.
+// NOT a decode-until-stable loop, which is the js/double-escaping bug class to
+// avoid — normalizes this feed's shape and stays deterministic.
 const decodeFeedText = (s) => decodeXmlEntities(decodeXmlEntities(s));
 
 /**
  * Extract the raw text of the first <tag>…</tag> in a block, handling both
  * CDATA (<tag><![CDATA[…]]></tag>) and plain text. Returns the value UNDECODED
- * so the caller can apply the exactly-two-pass `decodeFeedText` uniformly
- * (mirrors the parent's extractTag).
+ * so the caller can apply the exactly-two-pass `decodeFeedText` uniformly.
  */
 function extractTag(block, tag) {
   const re = new RegExp(
@@ -102,8 +100,8 @@ function cleanUrl(value) {
 
 /**
  * Split "Role at Company" on the LAST " at " occurrence. Falls back to an empty
- * company when the pattern isn't found (mirrors the parent — no default
- * company). Exported for unit tests.
+ * company when the pattern isn't found (no default company). Exported for unit
+ * tests.
  *
  * @param {string} raw
  * @returns {{ title: string; company: string }}
@@ -139,7 +137,7 @@ export function parseCryptocurrencyJobsRss(xml, maxResults) {
     if (jobs.length >= cap) break;
     try {
       const rawTitle = decodeFeedText(extractTag(item, 'title'));
-      // link is the dedup key; the parent falls back to <guid> when <link> is
+      // link is the dedup key; it falls back to <guid> when <link> is
       // absent, both host-pinned to cryptocurrencyjobs.co for SSRF safety.
       const url = cleanUrl(extractTag(item, 'link')) || cleanUrl(extractTag(item, 'guid'));
       if (!rawTitle || !url) continue;

--- a/server/lib/sources/csod.mjs
+++ b/server/lib/sources/csod.mjs
@@ -4,7 +4,7 @@
  *   https://{tenant}.csod.com/ux/ats/careersite/{siteId}/home?c={corpName}
  * (e.g. OHB: career-ohb.csod.com/ux/ats/careersite/4/home?c=career-ohb).
  *
- * Ported from parent career-ops `providers/csod.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). The search API is
  * public but wants a bearer token; the career-site home page is a small
  * (~5 KB) bootstrap document that embeds an ANONYMOUS JWT as `"token":"eyJ…"`
@@ -15,20 +15,20 @@
  *      → {data: {totalCount, requisitions: [{requisitionId, displayJobTitle,
  *          postingEffectiveDate: "M/D/YYYY", locations: [{city,state,country}]}]}}
  *
- * Job detail URL (verified live in the parent):
+ * Job detail URL:
  *   {origin}/ux/ats/careersite/{siteId}/home/requisition/{id}?c={corpName}
  *
  * SSRF defence: host is pinned to `csod.com` / `*.csod.com` via CSOD_HOST_RE
  * (checked in resolveConfig AND re-asserted on the endpoint in the fetcher),
- * HTTPS only, `redirect:'error'` on every request. Safety caps preserved from
- * the parent: PAGE_SIZE=25, MAX_PAGES=40, MAX_JOBS=1000.
+ * HTTPS only, `redirect:'error'` on every request. Safety caps: PAGE_SIZE=25,
+ * MAX_PAGES=40, MAX_JOBS=1000.
  *
  * Used by the csod adapter (server/lib/portals/adapters/csod.mjs).
  */
 import { fetchJson, fetchResponse, delay } from '../http-json.mjs';
 
 /**
- * v1.177.0 (parent #2769) — build a `Cookie` request header from the bootstrap
+ * v1.177.0 — build a `Cookie` request header from the bootstrap
  * response's `Set-Cookie` headers. Only the leading `name=value` pair is
  * meaningful on a request; attributes (Path/HttpOnly/Secure/SameSite/Expires)
  * describe browser-jar storage and are dropped. A repeated name takes its last
@@ -56,7 +56,7 @@ export const meta = {
   region: 'en',
 };
 
-const PAGE_SIZE = 25; // server default; the parent verified OHB serves exactly 25/page
+const PAGE_SIZE = 25; // server default; OHB serves exactly 25/page
 const MAX_PAGES = 40; // safety cap on request count (40*25 = 1000 postings)
 const MAX_JOBS = 1000; // cap total postings pulled per site
 const PAGE_DELAY_MS = 120; // polite pacing between search requests
@@ -77,7 +77,7 @@ export function resolveConfig(company) {
   } catch {
     return null;
   }
-  if (u.protocol !== 'https:') return null; // https only (web-ui hardening; parent also allowed http)
+  if (u.protocol !== 'https:') return null; // https only (web-ui hardening)
   if (!CSOD_HOST_RE.test(u.hostname)) return null;
   const m = u.pathname.match(/\/ux\/ats\/careersite\/(\d+)(?:\/|$)/i);
   if (!m) return null;
@@ -197,7 +197,7 @@ function resolveMaxPages(company) {
 }
 
 /**
- * Fetch + normalize a CSOD tenant's postings with the parent's bounded paged
+ * Fetch + normalize a CSOD tenant's postings with a bounded paged
  * walk: token from the home page, then POST-paginate the search API until
  * totalCount, an empty page, a no-fresh-ids page, or MAX_JOBS. A missing token
  * is a hard error (never a silent empty scan).
@@ -213,7 +213,7 @@ export async function fetchCsod(endpoint, opts = {}) {
 
   // The bootstrap page yields two things, not one: the anonymous bearer token,
   // and — on some tenants — the session cookies the search API demands (it
-  // answers "401 CSOD Unauthorized" until they come back with it; parent #2769).
+  // answers "401 CSOD Unauthorized" until they come back with it).
   // Read the response through fetchResponse to see Set-Cookie, then replay it as
   // a Cookie header on the search POST. Same-origin only (assertCsodUrl pins the
   // host; redirect:'error' keeps a 3xx from moving the cookies to another host),

--- a/server/lib/sources/dassault.mjs
+++ b/server/lib/sources/dassault.mjs
@@ -9,7 +9,7 @@
  *       &r=f/card_content_categories_facet/cards language/en   # only the English copy
  *       &start={offset}                                        # 0-based, 10 hits/page
  *
- * Ported from parent career-ops `providers/dassault.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). Single-company,
  * zero-token; the endpoint is global to 3ds.com so it is provider-selected
  * (`provider: dassault`) like ibm / amazon — there is no per-tenant config.

--- a/server/lib/sources/deutschebahn.mjs
+++ b/server/lib/sources/deutschebahn.mjs
@@ -17,7 +17,7 @@
  *   </a>
  * data-job-id is the dedup key; the href resolves to the public posting.
  *
- * Ported from parent career-ops `providers/deutschebahn.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta`). The board runs into the
  * thousands, so ITEMS_PER_PAGE + MAX_PAGES + MAX_JOBS bound the walk and the
  * scanner's title_filter does the real narrowing. Host-pinned to db.jobs (or

--- a/server/lib/sources/echojobs.mjs
+++ b/server/lib/sources/echojobs.mjs
@@ -11,7 +11,7 @@
  * fetch is host-locked (ECHOJOBS_HOST_RE) + `redirect:'error'`. The per-job url
  * is display-only and never server-fetched here.
  *
- * Ported from parent career-ops `providers/echojobs.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta`). Board-wide, so it is provider-selected
  * (`provider: echojobs`) — there is no per-tenant host.
  *

--- a/server/lib/sources/eightfold.mjs
+++ b/server/lib/sources/eightfold.mjs
@@ -4,7 +4,7 @@
  * (zero-auth GET, no token/cookie). Eightfold hosts branded career sites for
  * large enterprises (Bayer, Vodafone, PepsiCo, Autodesk, Micron, …).
  *
- * Ported from parent career-ops `providers/eightfold.mjs` (#2684) into the
+ * Implements the
  * web-ui source contract (rich job objects + `meta` for auto-discovery).
  *
  * Host pattern (per-tenant, host-pinned):
@@ -83,8 +83,8 @@ export function assertEightfoldUrl(url) {
  * Resolve the tenant host (+ optional domain) from a host-pinned URL — either
  * the entry's careers_url/api or the endpoint the adapter derived from it.
  * Returns null (never throws) for anything off-host, non-https or unparseable,
- * so the adapter can host-pin an override and drop it silently. Mirrors the
- * parent's `resolveTenant`, keyed off a URL string rather than the raw entry.
+ * so the adapter can host-pin an override and drop it silently. Keyed off a URL
+ * string rather than the raw entry.
  *
  * @param {string} rawUrl
  * @returns {{host: string, domain: (string|null)}|null}

--- a/server/lib/sources/flowxtra.mjs
+++ b/server/lib/sources/flowxtra.mjs
@@ -5,14 +5,14 @@
  *          city_company, state_company, country_company, workplace,
  *          date_share, ... } ], next_page_url, last_page, per_page, total } }
  *
- * Ported from parent career-ops `providers/flowxtra.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. One call lists live postings from every company using
  * Flowxtra as its ATS, so this is a board-wide aggregator like Himalayas /
  * Arbeitnow — the en-scanner's title_filter narrows the result afterwards.
  *
  * The apply URL (`urlJobApplay`) is host-locked to flowxtra.com and the API
  * endpoint is host-pinned to app.flowxtra.com over HTTPS with `redirect:'error'`
- * on every page, closing the SSRF redirect vector the parent guards.
+ * on every page, closing the SSRF redirect vector.
  *
  * Used by the flowxtra adapter (server/lib/portals/adapters/flowxtra.mjs).
  */

--- a/server/lib/sources/gem.mjs
+++ b/server/lib/sources/gem.mjs
@@ -3,15 +3,14 @@
  * Gem source — per-tenant career board served by the public jobs.gem.com
  * GraphQL *batch* endpoint behind the `jobs.gem.com/<boardId>` SPA boards.
  *
- * Ported from parent career-ops `providers/gem.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). The endpoint is a
  * single fixed host (`jobs.gem.com`) — NOT a per-tenant subdomain — and the
  * per-company board id comes from the entry's `careers_url`
  * (`https://jobs.gem.com/<boardId>`), threaded through the endpoint's
  * `?board=<boardId>` query param by the adapter.
  *
- * Two unauthenticated POSTs (no auth headers, no cookies — verified live in the
- * parent):
+ * Two unauthenticated POSTs (no auth headers, no cookies — verified live):
  *   - JobBoardList(boardId): the listing — title, locations, department,
  *     employment/location type, but NO date field.
  *   - ExternalJobPostingQuery(boardId, extId): per-job detail carrying

--- a/server/lib/sources/getonbrd.mjs
+++ b/server/lib/sources/getonbrd.mjs
@@ -3,7 +3,7 @@
  * Get on Board source — board-wide feed for the tech "programming" category
  *   GET https://www.getonbrd.com/api/v0/categories/programming/jobs
  *
- * Ported from parent career-ops `providers/getonbrd.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). Public, zero-auth
  * JSON:API; `expand[]=company` embeds the company name at the list level. The
  * broad category feed is fetched (not the server-side ?query= search) so the
@@ -52,7 +52,7 @@ function resolveMaxPages(entry) {
 
 function toIsoDate(epochSeconds) {
   // Guard 0/negative epochs — a `published_at` of 0 would otherwise render a
-  // bogus 1970-01-01 date. (parent career-ops parity, #1528)
+  // bogus 1970-01-01 date.
   if (!Number.isFinite(epochSeconds) || epochSeconds <= 0) return '';
   const d = new Date(epochSeconds * 1000);
   return Number.isNaN(d.getTime()) ? '' : d.toISOString().slice(0, 10);

--- a/server/lib/sources/glints.mjs
+++ b/server/lib/sources/glints.mjs
@@ -2,7 +2,7 @@
  * Glints source — hits the undocumented public GraphQL endpoint that powers
  * glints.com job search (covers Singapore, Indonesia, Malaysia, Vietnam).
  *
- * Ported from parent career-ops v1.12.0 `providers/glints.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. Glints is an aggregator, not a company ATS, so it is only
  * selected via an explicit `provider: glints` entry — never auto-detected.
  * Config comes from the company entry, read via `opts.company`:
@@ -176,7 +176,7 @@ export async function fetchGlints(apiUrl = DEFAULT_API, opts = {}) {
         headers: {
           'content-type': 'application/json',
           // Glints' firewall blocks generic UAs outright — a browser-like UA
-          // + origin/referer clears it (parent career-ops providers/glints.mjs).
+          // + origin/referer clears it.
           'user-agent': BROWSER_LIKE_USER_AGENT,
           origin: 'https://glints.com',
           referer: 'https://glints.com/id/opportunities/jobs/explore',

--- a/server/lib/sources/greenhouse.mjs
+++ b/server/lib/sources/greenhouse.mjs
@@ -13,7 +13,7 @@ export const meta = {
   region: 'en',
 };
 
-// ── Office enrichment (parent #2104) ────────────────────────────────
+// ── Office enrichment ───────────────────────────────────────────────
 // Some Greenhouse boards put the *work model* ("Hybrid", "In-Office",
 // "Distributed") in location.name and keep the actual city only in the
 // separate /offices endpoint — which the /jobs list does not embed. For those
@@ -98,9 +98,9 @@ export async function fetchGreenhouse(apiUrl, opts = {}) {
 function normalize(j, officeMap = null) {
   let loc = j.location?.name || '';
   const offices = (j.offices || []).map((o) => o.name).filter(Boolean);
-  // Parent #2104: when the job's location is a bare work model and /jobs
+  // When the job's location is a bare work model and /jobs
   // embedded no offices, recover the city from the /offices map and fold it
-  // into the location string (matching the parent's `[loc, ...offices]` join)
+  // into the location string (a `[loc, ...offices]` join)
   // so the returned `location` field — and downstream filtering — sees it.
   if (officeMap && isWorkModelOnly(loc) && !offices.length) {
     const fromMap = officeMap.get(j.id);

--- a/server/lib/sources/hackernews.mjs
+++ b/server/lib/sources/hackernews.mjs
@@ -4,7 +4,7 @@
  * Two-step fetch via Algolia HN API:
  *   1. GET SEARCH_URL → find the latest monthly hiring thread objectID, filtered
  *      to stories posted by the "whoishiring" account (tags=story,author_whoishiring)
- *      rather than a free-text query (parent #3aa5e15). A free-text
+ *      rather than a free-text query. A free-text
  *      "Ask HN Who is hiring" query against search_by_date can, once enough time
  *      passes since the monthly thread posted, rank an unrelated recent story
  *      above it in the top date-sorted hits — every one fails the title regex

--- a/server/lib/sources/hecklerkoch.mjs
+++ b/server/lib/sources/hecklerkoch.mjs
@@ -3,7 +3,7 @@
  * Heckler & Koch source — SSR vacancy list at
  *   https://www.heckler-koch.com/de/Karriere/Stellenangebote
  *
- * Ported from parent career-ops `providers/hecklerkoch.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta` for auto-discovery). Single
  * company, zero-token: the Nuxt listing page is SERVER-rendered, so one bare
  * HTTP GET returns every posting (small board, ~32 roles). The apply backend
@@ -61,8 +61,8 @@ export function assertHecklerkochUrl(url) {
 
 /**
  * Resolve the vacancy-list URL from a company's api:/careers_url; any other
- * path on the trusted host defaults to the DE Stellenangebote list (same
- * behaviour as the parent's resolveListUrl, https-only per web-ui policy).
+ * path on the trusted host defaults to the DE Stellenangebote list
+ * (https-only per web-ui policy).
  * Returns null for foreign/spoofed hosts. Exported for the adapter + tests.
  * @param {{ api?: string, careers_url?: string }} company
  */

--- a/server/lib/sources/higheredjobs.mjs
+++ b/server/lib/sources/higheredjobs.mjs
@@ -3,7 +3,7 @@
  * HigherEdJobs source — board-wide RSS category feed.
  *   GET https://www.higheredjobs.com/rss/categoryFeed.cfm?catID={catID}
  *
- * Ported from parent career-ops `providers/higheredjobs.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta` for auto-discovery).
  *
  * The feed is public, no-auth XML, parsed in-process with the same tiny tag

--- a/server/lib/sources/himalayas.mjs
+++ b/server/lib/sources/himalayas.mjs
@@ -2,7 +2,7 @@
  * Himalayas source — board-wide remote-jobs public JSON API.
  *   GET https://himalayas.app/jobs/api?limit=50  → { jobs: [...] }
  *
- * Ported from parent career-ops `providers/himalayas.mjs` into the
+ * Implements the
  * web-ui source contract. The full feed is fetched so the en-scanner's
  * title_filter can gate on configured titles consistently with other
  * zero-token board providers. Himalayas is a remote-only board so

--- a/server/lib/sources/ibm.mjs
+++ b/server/lib/sources/ibm.mjs
@@ -3,7 +3,7 @@
  * (the same endpoint ibm.com/careers/search calls). One endpoint serves every
  * locale (lang: "zz"), so results are language-agnostic.
  *
- * Ported from parent career-ops v1.12.0 `providers/ibm.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. Config comes from the company entry's `ibm:` block, read
  * via `opts.company` (the en-scanner passes the resolved company through):
  *

--- a/server/lib/sources/icims.mjs
+++ b/server/lib/sources/icims.mjs
@@ -1,9 +1,8 @@
 // @ts-check
 /**
  * iCIMS source — scrapes the classic public hosted-portal search pages served
- * at `careers-<tenant>.icims.com`. Ported from parent career-ops
- * `providers/icims.mjs` into the web-ui source contract (rich job objects +
- * `meta` for auto-discovery).
+ * at `careers-<tenant>.icims.com`. Implements the web-ui source contract (rich
+ * job objects + `meta` for auto-discovery).
  *
  * DISTINCT from the `jibeapply` source: that one targets JibeApply (iCIMS's
  * apply product); this one targets the classic iCIMS hosted job-search portal.
@@ -12,8 +11,8 @@
  * Canonical URL: `https://careers-<tenant>.icims.com/jobs/search?ss=1`. The
  * `in_iframe=1` variant selects the lighter portal-only markup, and `pr` is the
  * 0-based page index. List pages carry title / location / URL but NO posted
- * date — the parent has an `enrichDate()` hook that fetches each detail page's
- * JSON-LD for `datePosted`, but the web-ui in-process scanner returns jobs
+ * date — reading `datePosted` would require an `enrichDate()` hook that fetches
+ * each detail page's JSON-LD, but the web-ui in-process scanner returns jobs
  * directly and does NOT support a per-job enrich hook, so that hook is OMITTED
  * here: every job is returned undated (`date: ''`), same as other web-ui
  * sources that carry no list-page date.

--- a/server/lib/sources/jibeapply.mjs
+++ b/server/lib/sources/jibeapply.mjs
@@ -6,10 +6,10 @@
  * branded custom domain — those are wired with an explicit `api:` on the
  * portals.yml entry.
  *
- * Ported from parent career-ops `providers/jibeapply.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta`). Pagination is sequential (a
  * single tenant's API has no reason to receive a parallel burst, and a mid-run
- * failure keeps the pages already gathered) with the parent's safety cap —
+ * failure keeps the pages already gathered) with a safety cap —
  * DEFAULT_MAX_PAGES=50, hard cap 500 via `max_pages` on the entry — applied
  * regardless of the upstream-reported totalCount, so a misbehaving API can't
  * drive thousands of requests. `redirect:'error'` (SSRF-safe).
@@ -90,7 +90,7 @@ export function parseJibeapplyResponse(json, company = {}) {
 }
 
 /**
- * Fetch + parse a tenant's postings with the parent's sequential paged walk.
+ * Fetch + parse a tenant's postings with a sequential paged walk.
  * `endpoint` is the /api/jobs URL from the adapter's buildEndpoint.
  */
 export async function fetchJibeapply(endpoint, opts = {}) {

--- a/server/lib/sources/jobicy.mjs
+++ b/server/lib/sources/jobicy.mjs
@@ -2,7 +2,7 @@
  * Jobicy source — board-wide remote-jobs aggregator JSON API.
  *   GET https://jobicy.com/api/v2/remote-jobs?count=50 → { jobs: [...] }
  *
- * Ported from parent career-ops `providers/jobicy.mjs` into the
+ * Implements the
  * web-ui source contract. The full feed is fetched so the
  * en-scanner's title_filter can gate on configured titles.
  *

--- a/server/lib/sources/jobspresso.mjs
+++ b/server/lib/sources/jobspresso.mjs
@@ -3,7 +3,7 @@
  * Jobspresso source — board-wide remote-jobs RSS/XML feed.
  *   GET https://jobspresso.co/?feed=job_feed
  *
- * Ported into the web-ui source contract (rich job objects + `meta` for
+ * Implements the web-ui source contract (rich job objects + `meta` for
  * auto-discovery). The feed is public, no-auth XML, parsed in-process with a
  * tiny tag extractor — no XML dependency. The host is pinned to jobspresso.co
  * and the fetch uses `redirect:'error'` (SSRF-safe). Every posting is remote,

--- a/server/lib/sources/jobstreet.mjs
+++ b/server/lib/sources/jobstreet.mjs
@@ -4,7 +4,7 @@
  * seek.co.nz) share the same SEEK infrastructure and expose a no-auth JSON
  * search endpoint at /api/chalice-search/v4/search.
  *
- * Ported from parent career-ops v1.12.0 `providers/jobstreet.mjs` into the
+ * Implements the
  * web-ui source contract. Aggregator, not an ATS — selected only via explicit
  * `provider: jobstreet`. Config comes from the company entry, read via
  * `opts.company`:

--- a/server/lib/sources/jobvite.mjs
+++ b/server/lib/sources/jobvite.mjs
@@ -2,7 +2,7 @@
 /**
  * Jobvite source — per-tenant public jobs feed. Used by ~3,000 companies.
  *
- * Ported from parent career-ops `providers/jobvite.mjs` (#2623 migration) into
+ * Implements
  * the web-ui source contract (rich job objects + `meta` for auto-discovery).
  *
  * ───────────────────────────────────────────────────────────────────────────
@@ -85,7 +85,7 @@ export function assertJobviteUrl(url) {
   return url;
 }
 
-// NaN-safe Date.parse → epoch ms (parent career-ops parity).
+// NaN-safe Date.parse → epoch ms.
 /** @param {string} value */
 function toEpochMs(value) {
   if (!value) return undefined;
@@ -216,8 +216,7 @@ export function isEmptyBoardRedirect(err, requestUrl) {
 // indexOf cursor scanning rather than `xml.matchAll(/<job>([\s\S]*?)<\/job>/g)`
 // and per-tag regexes. The feed is a remote document that can reach ~1.9 MB;
 // the obvious lazy patterns are polynomial-backtracking on input that never
-// closes a tag (CodeQL js/polynomial-redos, high). indexOf walks it once. This
-// mirrors the parent's fixed provider, which switched to the same technique.
+// closes a tag (CodeQL js/polynomial-redos, high). indexOf walks it once.
 
 /** Read one tag out of a `<job>` block, unwrapping CDATA. Index-based (no regex). */
 function tagText(block, name) {

--- a/server/lib/sources/join.mjs
+++ b/server/lib/sources/join.mjs
@@ -4,7 +4,7 @@
  * `__NEXT_DATA__` JSON blob embedded in the SSR-rendered careers-page HTML.
  * No API key needed — the board is server-rendered into the page.
  *
- * Ported from parent career-ops `providers/join.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). join.com hosts one
  * board per company at https://join.com/companies/<slug>, so a tracked entry is
  * auto-detected from a join.com careers_url (mirrored by the adapter's
@@ -102,8 +102,8 @@ function extractInitialState(html) {
  * it is not ingestible (no `idParam` — the url/id both depend on it, and url is
  * the dedup key). Exported for tests.
  *
- * Field mapping mirrors the parent provider (title/url/company/location) and
- * fills the remaining web-ui fields the same way manfred.mjs does:
+ * Field mapping (title/url/company/location) fills the remaining web-ui fields
+ * the same way manfred.mjs does:
  *   - date is always '' (the list item carries no reliable publication date).
  *   - relocates is derived from a visa/relocation/sponsorship hit on the title.
  *   - isRemote/workplaceType are derived from the location signal (join's list
@@ -172,7 +172,7 @@ export async function fetchJoin(endpoint, opts = {}) {
   }
 
   // The tenant domain (falls back to the URL slug) pins every emitted job url
-  // and is fixed by the first page for the whole crawl (parent parity).
+  // and is fixed by the first page for the whole crawl.
   const companySlug = firstState.company?.domain || slug;
 
   const out = [];

--- a/server/lib/sources/joinup.mjs
+++ b/server/lib/sources/joinup.mjs
@@ -2,8 +2,8 @@
 /**
  * joinup.ch source — Swiss startup job platform (Typesense-backed Next.js).
  *
- * Implements the web-ui source contract (rich job objects + `meta` for auto-discovery). Detected from a
- * `careers_url` whose host is joinup.ch.
+ * Implements the web-ui source contract (rich job objects + `meta` for
+ * auto-discovery). Detected from a `careers_url` whose host is joinup.ch.
  *
  * The browse page server-renders the newest page of results into __NEXT_DATA__
  * at props.pageProps.serverState.initialResults.jobs.results[0].hits[]. The full

--- a/server/lib/sources/joinup.mjs
+++ b/server/lib/sources/joinup.mjs
@@ -2,8 +2,7 @@
 /**
  * joinup.ch source — Swiss startup job platform (Typesense-backed Next.js).
  *
- * Implements the web-ui source
- * contract (rich job objects + `meta` for auto-discovery). Detected from a
+ * Implements the web-ui source contract (rich job objects + `meta` for auto-discovery). Detected from a
  * `careers_url` whose host is joinup.ch.
  *
  * The browse page server-renders the newest page of results into __NEXT_DATA__

--- a/server/lib/sources/joinup.mjs
+++ b/server/lib/sources/joinup.mjs
@@ -2,7 +2,7 @@
 /**
  * joinup.ch source — Swiss startup job platform (Typesense-backed Next.js).
  *
- * Ported from parent career-ops `providers/joinup.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). Detected from a
  * `careers_url` whose host is joinup.ch.
  *
@@ -18,7 +18,7 @@
  * Public posting URL: https://joinup.ch/job/{slug}
  *
  * SINGLE-request board — no pagination. So the dead-board contract collapses to
- * its simplest form (parity with the parent + manfred): the sole request IS
+ * its simplest form (parity with manfred): the sole request IS
  * "page 1", and because nothing has succeeded before it, a fetch failure OR a
  * missing/unparseable __NEXT_DATA__ THROWS rather than being swallowed into an
  * empty result. A scraper break is not an empty board — failing closed lets

--- a/server/lib/sources/landingjobs.mjs
+++ b/server/lib/sources/landingjobs.mjs
@@ -2,7 +2,7 @@
  * Landing.jobs source — board-wide tech/Europe-focused aggregator feed.
  *   GET https://landing.jobs/api/v1/jobs  → JSON array of postings
  *
- * Ported from parent career-ops `providers/landingjobs.mjs` into the
+ * Implements the
  * web-ui source contract.
  *
  * NOTE: the v1 feed carries no company-name field — the employer slug only

--- a/server/lib/sources/larajobs.mjs
+++ b/server/lib/sources/larajobs.mjs
@@ -3,7 +3,7 @@
  * LaraJobs source — board-wide Laravel/PHP jobs RSS feed.
  *   GET https://larajobs.com/feed
  *
- * Ported from parent career-ops `providers/larajobs.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta` for auto-discovery).
  *
  * The feed is public, no-auth XML, parsed in-process with the same tiny tag

--- a/server/lib/sources/manfred.mjs
+++ b/server/lib/sources/manfred.mjs
@@ -3,12 +3,12 @@
  * getManfred source — board-wide public JSON feed of Spanish/EU tech jobs
  *   GET https://www.getmanfred.com/api/v2/public/offers?lang=EN
  *
- * Ported from parent career-ops `providers/manfred.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery). Public, zero-auth,
  * and returned in ONE call: the endpoint has no pagination parameters and
  * answers with the full catalogue.
  *
- * Two things measured against the live feed shape this source (parent parity):
+ * Two things measured against the live feed shape this source:
  *
  *   1. The feed is a CATALOGUE, NOT A LIVE BOARD. The vast majority of entries
  *      carry `status: "CLOSED"`; only a small slice are ACTIVE. Ingesting it
@@ -46,7 +46,7 @@ export const meta = {
 
 /**
  * Defence-in-depth host check on the endpoint built by the adapter. Throws on
- * failure. Mirrors the parent provider's `assertManfredUrl`.
+ * failure.
  * @param {string} url
  * @returns {string} the same URL if valid
  */
@@ -187,7 +187,7 @@ export function resolveLocation(offer) {
  * NO date: the only timestamp in the payload is `updatedAt`, which is a
  * modification time, not a publication date. Mapping it to `date` would make an
  * edited old posting look freshly published to the recency filters, so the
- * field is left empty (parent parity — the parent omits `postedAt` outright).
+ * field is left empty (no `postedAt` is emitted).
  *
  * @param {any} offer
  * @param {string} [fallbackCompany]

--- a/server/lib/sources/meituan.mjs
+++ b/server/lib/sources/meituan.mjs
@@ -2,7 +2,7 @@
  * Meituan careers source — posts to the public zhaopin.meituan.com JSON API
  * (no auth, no browser, no special headers).
  *
- * Ported from parent career-ops `providers/meituan.mjs` (#1818) into the
+ * Implements the
  * web-ui source contract. Meituan is a single-company board, so it is
  * selected via an explicit `provider: meituan` entry or auto-detected from a
  * zhaopin.meituan.com careers_url. Config comes from the company entry, read

--- a/server/lib/sources/nodesk.mjs
+++ b/server/lib/sources/nodesk.mjs
@@ -3,7 +3,7 @@
  * NoDesk source — board-wide remote-jobs RSS feed.
  *   GET https://nodesk.co/remote-jobs/index.xml
  *
- * Ported from parent career-ops v1.15.0 `providers/nodesk.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta` for auto-discovery).
  *
  * The feed is public, no-auth XML, parsed in-process with a tiny tag extractor

--- a/server/lib/sources/nofluffjobs.mjs
+++ b/server/lib/sources/nofluffjobs.mjs
@@ -2,14 +2,14 @@
  * NoFluffJobs source — Poland-focused job board.
  *   POST https://nofluffjobs.com/api/search/posting  → { postings: [...] }
  *
- * Ported from parent career-ops `providers/nofluffjobs.mjs` into the
+ * Implements the
  * web-ui source contract. Uses a single-page POST (no pagination) so the
  * en-scanner's title_filter can gate on configured titles.
  *
  * Used by the nofluffjobs adapter (server/lib/portals/adapters/nofluffjobs.mjs).
  *
- * Content-Type note: the parent sends 'application/infiniteSearch+json' — we
- * replicate that exactly so the API returns a full result set.
+ * Content-Type note: the request sends 'application/infiniteSearch+json' — we
+ * set that exactly so the API returns a full result set.
  */
 const UA = 'career-ops-web-ui/1.0';
 
@@ -106,7 +106,6 @@ function normalize(p) {
 
 /**
  * Build the POST body for an open (no keyword filter) search.
- * Mirrors the parent's criteriaSearch body exactly.
  */
 function buildBody() {
   return {

--- a/server/lib/sources/oraclecloud.mjs
+++ b/server/lib/sources/oraclecloud.mjs
@@ -5,7 +5,7 @@
  * career sites. Large employers (JPMorgan Chase, Oracle, BNY Mellon, American
  * Express, Honeywell, …) run their careers site on ORC.
  *
- * Ported from parent career-ops `providers/oraclecloud.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta` for auto-discovery).
  *
  * Host patterns (per-tenant, dynamic):
@@ -36,7 +36,7 @@
  * Pagination NOTE: `hasMore` is unreliable on some tenants (JPMC returns
  * hasMore:false on EVERY page even with 7000+ jobs), so it is NOT used to
  * stop — trusting it caps the scan at one page. The authoritative signals are
- * the returned list length and TotalJobsCount (parent career-ops parity).
+ * the returned list length and TotalJobsCount.
  *
  * Known limitation: some tenants front the API with a WAF (e.g. Imperva) that
  * 403s datacenter/cloud egress IPs. That's an environment/IP issue, not a
@@ -56,7 +56,7 @@ import { decodeEntities } from '../html-entities.mjs';
 // `oraclecloud(?:[1-9][0-9]?)?` = the unnumbered apex plus the numbered family
 // oraclecloud1.com … oraclecloud99.com (some tenants live only on a numbered
 // apex, e.g. `<tenant>.fa.ocs.oraclecloud26.com`, whose unnumbered sibling does
-// not resolve — parent career-ops #2683). No leading zero and at most two digits
+// not resolve). No leading zero and at most two digits
 // keeps this a BOUNDED host pin, never a wildcard `oraclecloud<anything>.com`.
 export const ORACLE_HOST_RE = /^[a-z0-9-]+\.fa\.(?:[a-z0-9-]+\.)?(?:ocs\.)?oraclecloud(?:[1-9][0-9]?)?\.com$/i;
 
@@ -95,7 +95,7 @@ function clean(s) {
 }
 
 // NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
-// (parent career-ops parity, copied from greenhouse.mjs upstream)
+// (shared with greenhouse.mjs)
 function toEpochMs(value) {
   if (!value) return undefined;
   const parsed = Date.parse(value);
@@ -106,7 +106,7 @@ function toEpochMs(value) {
  * Resolve ORC coordinates from a careers/api URL (+ optional company-entry
  * overrides). The URL is the host-pinned endpoint the adapter derived from the
  * entry's `api:`/careers_url. Honors optional `entry.siteNumber` /
- * `entry.locationId` overrides (parent career-ops parity).
+ * `entry.locationId` overrides.
  *
  * @param {string} rawUrl host-pinned ORC careers URL
  * @param {{ siteNumber?: string, locationId?: string|number }} [entry]

--- a/server/lib/sources/personio.mjs
+++ b/server/lib/sources/personio.mjs
@@ -4,7 +4,7 @@
  *   GET https://<slug>.jobs.personio.(de|com)/xml
  * (common across DACH/EU companies).
  *
- * Ported from parent career-ops v1.13.0 `providers/personio.mjs` into the web-ui
+ * Implements the web-ui
  * source contract. Per-tenant subdomains vary, so the SSRF defence is an anchored
  * host regex (same approach as bamboohr/breezy) plus `redirect:'error'`. The feed
  * is a flat, well-defined XML document parsed in-process with a tiny tag extractor

--- a/server/lib/sources/phenom.mjs
+++ b/server/lib/sources/phenom.mjs
@@ -12,7 +12,7 @@
  *        "data":{"jobs":[{"jobId":"98098","title":…,"city":…,"state":…,
  *          "country":…,"location":…,"postedDate":"…ISO…"}]}}}
  *
- * Ported from parent career-ops `providers/phenom.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta`). `from` is a 0-based offset; `size` up
  * to 100/page. The public job page is {origin}/{urlPrefix}/job/{jobId}/{slug}
  * — the slug is cosmetic (Phenom keys on jobId), so we slugify the title. The
@@ -26,8 +26,8 @@
  * "phenom" token, so PHENOM_HOST_RE (auto-detect) only claims literal
  * *.phenompeople.com URLs — branded tenants are wired with an explicit
  * `provider: phenom`, and the endpoint is then pinned to the tenant host the
- * adapter derived from the entry (same model as successfactors). Safety caps
- * preserved from the parent: PAGE_SIZE=100, MAX_PAGES=40, MAX_JOBS=1000.
+ * adapter derived from the entry (same model as successfactors). Safety caps:
+ * PAGE_SIZE=100, MAX_PAGES=40, MAX_JOBS=1000.
  *
  * Used by the phenom adapter (server/lib/portals/adapters/phenom.mjs).
  */
@@ -43,7 +43,7 @@ export const meta = {
   region: 'en',
 };
 
-const PAGE_SIZE = 100; // max the widget serves per page (parent-verified)
+const PAGE_SIZE = 100; // max the widget serves per page
 const MAX_PAGES = 40; // safety cap on request count (40*100 = 4000 postings)
 const MAX_JOBS = 1000; // cap total postings pulled per site
 const PAGE_DELAY_MS = 150; // polite pacing between page requests
@@ -62,7 +62,7 @@ export function resolveConfig(company) {
   } catch {
     return null;
   }
-  if (u.protocol !== 'https:') return null; // https only (web-ui hardening; parent also allowed http)
+  if (u.protocol !== 'https:') return null; // https only (web-ui hardening)
   const block = company.phenom && typeof company.phenom === 'object' ? company.phenom : {};
   const urlPrefix = String(block.urlPrefix || 'global/en').replace(/^\/+|\/+$/g, '');
   return {
@@ -170,7 +170,7 @@ function resolveMaxPages(company) {
 }
 
 /**
- * Fetch + normalize a Phenom tenant's postings with the parent's bounded paged
+ * Fetch + normalize a Phenom tenant's postings with a bounded paged
  * walk (from/size offsets until totalHits, dedup across pages). A transient
  * mid-scan failure keeps the jobs collected so far — it never discards
  * earlier pages.

--- a/server/lib/sources/radancy.mjs
+++ b/server/lib/sources/radancy.mjs
@@ -14,18 +14,18 @@
  * markup (a second, module-numbered `job-list-NN-list__` prefix rides
  * alongside it and varies per site) — we anchor on the generic one.
  *
- * Ported from parent career-ops `providers/radancy.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta`). The list carries no posting date, so
  * `date` is always ''. Branded hosts carry no stable Radancy token, so there
  * is NO host regex / auto-detection — tenants are wired with an explicit
  * `provider: radancy` and a search-jobs `api:`/careers_url; the endpoint is
  * then pinned to the tenant host the adapter derived from the entry (same
  * model as successfactors), enforced HTTPS + `redirect:'error'` and a
- * /search-jobs path shape via assertRadancyUrl. Safety caps preserved from
- * the parent: MAX_PAGES=200, DEFAULT_MAX_JOBS=2000 (overridable per-entry via
+ * /search-jobs path shape via assertRadancyUrl. Safety caps: MAX_PAGES=200,
+ * DEFAULT_MAX_JOBS=2000 (overridable per-entry via
  * `max_pages` / `max_jobs`).
  *
- * Two markup generations, two transports (parent parity):
+ * Two markup generations, two transports:
  *   (a) MODERN markup — <li class="search-results-list__item"> with a
  *       `search-results-list__job-link` anchor. Parsed by parseModernResults().
  *   (b) LEGACY markup — a bare <li> holding the anchor itself, no list-item
@@ -77,7 +77,7 @@ export function resolveListUrl(company) {
   } catch {
     return null;
   }
-  if (u.protocol !== 'https:') return null; // https only (web-ui hardening; parent also allowed http)
+  if (u.protocol !== 'https:') return null; // https only (web-ui hardening)
   if (/\/search-jobs\/?$/.test(u.pathname)) return `${u.origin}${u.pathname.replace(/\/$/, '')}`;
   const lang = (u.pathname.match(/^\/([a-z]{2})(\/|$)/) || [])[1] || 'en';
   return `${u.origin}/${lang}/search-jobs`;
@@ -305,8 +305,8 @@ function resolveMaxJobs(company) {
  * Preferred transport: the JSON results fragment (buildFragmentUrl) — on the
  * legacy-markup tenants the plain ?p=N HTML page carries a multi-megabyte facet
  * blob per page, so the fragment is dramatically cheaper. It is attempted only
- * when the caller supplies a `fetchJson` capability (mirrors the parent's
- * `ctx.fetchJson` gate); any failure — non-JSON, no results, endpoint absent —
+ * when the caller supplies a `fetchJson` capability; any failure — non-JSON, no
+ * results, endpoint absent —
  * falls through to the ?p=N walk below, so tenants without the fragment endpoint
  * (and callers that pass no fetchJson) are unaffected.
  *

--- a/server/lib/sources/recruitee.mjs
+++ b/server/lib/sources/recruitee.mjs
@@ -3,7 +3,7 @@
  * Recruitee source — hits the public per-tenant offers API.
  *   GET https://<slug>.recruitee.com/api/offers/
  *
- * Ported from parent career-ops `providers/recruitee.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract. Per-tenant subdomains vary, so the SSRF defence is an anchored host
  * regex plus `redirect:'error'`. The per-offer URL is commonly on the tenant's
  * own custom domain, so it is NOT host-locked (display-only, never server-fetched).

--- a/server/lib/sources/remoteok.mjs
+++ b/server/lib/sources/remoteok.mjs
@@ -2,7 +2,7 @@
  * RemoteOK source — board-wide remote-jobs aggregator feed.
  *   GET https://remoteok.com/api
  *
- * Ported from parent career-ops v1.12.0 `providers/remoteok.mjs` into the
+ * Implements the
  * web-ui source contract (rich job objects + `meta` for auto-discovery).
  *
  * The feed is a JSON array whose first element is a `{ legal, … }` metadata
@@ -36,7 +36,7 @@ function djb2(str) {
  */
 export async function fetchRemoteOk(feedUrl = FEED_URL, opts = {}) {
   const { fetchImpl = fetch, signal } = opts;
-  // redirect:'error' mirrors the parent provider's SSRF guard.
+  // redirect:'error' closes the SSRF-via-redirect vector.
   const res = await fetchImpl(feedUrl, {
     signal,
     redirect: 'error',

--- a/server/lib/sources/remotive.mjs
+++ b/server/lib/sources/remotive.mjs
@@ -2,7 +2,7 @@
  * Remotive source — board-wide remote-jobs aggregator feed.
  *   GET https://remotive.com/api/remote-jobs  → { jobs: [...] }
  *
- * Ported from parent career-ops v1.12.0 `providers/remotive.mjs` into the
+ * Implements the
  * web-ui source contract. The full feed is fetched (no ?search=) so the
  * en-scanner's title_filter can gate on the configured titles — the feed's
  * own ?search= is a narrow substring match that misses e.g. "ML Engineer".

--- a/server/lib/sources/remotli.mjs
+++ b/server/lib/sources/remotli.mjs
@@ -7,10 +7,10 @@
  *   → { jobs: [ { jobs: {...}, companies: {...} }, ... ],
  *       pagination: { page, limit, total, totalPages } }
  *
- * Ported from parent career-ops `providers/remotli.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta` for auto-discovery).
  *
- * Two shape notes measured on the live feed (parent parity):
+ * Two shape notes measured on the live feed:
  *
  *   1. Doubly-nested rows. Each element of the top-level `jobs` array is a JOIN
  *      row `{ jobs, companies }`, and the posting itself lives under `.jobs`.
@@ -99,7 +99,7 @@ export function toEpochMs(value) {
  * decode once — the house order, and the correct one for this API (it decodes on
  * the way out and always answers with real HTML). A second strip after the
  * decode is deliberately NOT added — it re-introduced two HIGH CodeQL alerts
- * (js/double-escaping, js/bad-tag-filter) on the parent before the API stopped
+ * (js/double-escaping, js/bad-tag-filter) before the API stopped
  * mixing entity-encoded and raw-HTML descriptions row by row. Exported for tests.
  * @param {unknown} html
  * @returns {string}
@@ -267,7 +267,7 @@ function pageUrl(base, page) {
  * (1-based) up to `pagination.totalPages`, capped by `company.max_pages` else
  * DEFAULT_MAX_PAGES, deduping by url. Host-pinned, `redirect:'error'` (SSRF-safe).
  *
- * Dead-board contract (parent v1.25.0): a page-1 failure — or a page-1 body that
+ * Dead-board contract: a page-1 failure — or a page-1 body that
  * is not `{ jobs: [...] }` — means we cannot tell a live board from a broken one,
  * so it THROWS and surfaces as a dead target. Once one page has parsed, the board
  * is provably reachable and a later transient failure keeps the partials already

--- a/server/lib/sources/rheinmetall.mjs
+++ b/server/lib/sources/rheinmetall.mjs
@@ -4,8 +4,8 @@
  *   https://www.rheinmetall.com/{lang}/career/vacancies?page=N
  *
  * Implements the web-ui source contract (rich job objects + `meta` for
- * auto-discovery). Single
- * company, zero-token: the Nuxt vacancy list is SERVER-rendered, so plain
+ * auto-discovery). Single company, zero-token: the Nuxt vacancy list is
+ * SERVER-rendered, so plain
  * `?page=N` pagination works over bare HTTP (~10 unique jobs/page, ~1350
  * total). No XHR API is exposed; the underlying Cornerstone TalentLink tenant
  * has no anonymous REST endpoint either, so parsing the SSR list is the path.

--- a/server/lib/sources/rheinmetall.mjs
+++ b/server/lib/sources/rheinmetall.mjs
@@ -3,7 +3,7 @@
  * Rheinmetall source — SSR vacancy list at
  *   https://www.rheinmetall.com/{lang}/career/vacancies?page=N
  *
- * Ported from parent career-ops `providers/rheinmetall.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta` for auto-discovery). Single
  * company, zero-token: the Nuxt vacancy list is SERVER-rendered, so plain
  * `?page=N` pagination works over bare HTTP (~10 unique jobs/page, ~1350

--- a/server/lib/sources/rheinmetall.mjs
+++ b/server/lib/sources/rheinmetall.mjs
@@ -3,8 +3,7 @@
  * Rheinmetall source — SSR vacancy list at
  *   https://www.rheinmetall.com/{lang}/career/vacancies?page=N
  *
- * Implements the web-ui
- * source contract (rich job objects + `meta` for auto-discovery). Single
+ * Implements the web-ui source contract (rich job objects + `meta` for auto-discovery). Single
  * company, zero-token: the Nuxt vacancy list is SERVER-rendered, so plain
  * `?page=N` pagination works over bare HTTP (~10 unique jobs/page, ~1350
  * total). No XHR API is exposed; the underlying Cornerstone TalentLink tenant

--- a/server/lib/sources/rheinmetall.mjs
+++ b/server/lib/sources/rheinmetall.mjs
@@ -3,7 +3,8 @@
  * Rheinmetall source — SSR vacancy list at
  *   https://www.rheinmetall.com/{lang}/career/vacancies?page=N
  *
- * Implements the web-ui source contract (rich job objects + `meta` for auto-discovery). Single
+ * Implements the web-ui source contract (rich job objects + `meta` for
+ * auto-discovery). Single
  * company, zero-token: the Nuxt vacancy list is SERVER-rendered, so plain
  * `?page=N` pagination works over bare HTTP (~10 unique jobs/page, ~1350
  * total). No XHR API is exposed; the underlying Cornerstone TalentLink tenant

--- a/server/lib/sources/softgarden.mjs
+++ b/server/lib/sources/softgarden.mjs
@@ -7,7 +7,7 @@
  * server-rendered document listing EVERY posting — no auth, no JS, no
  * pagination (filtering happens client-side via AJAX we don't need).
  *
- * Ported from parent career-ops `providers/softgarden.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta`). One posting renders as a
  * `<div class="matchElement" id="job_id_{id}">` block whose `<a href>` is
  * relative to the /{lang}/widgets/ path — resolved against the widget URL so

--- a/server/lib/sources/solidjobs.mjs
+++ b/server/lib/sources/solidjobs.mjs
@@ -3,7 +3,7 @@
  * SolidJobs source — hits the public offers API.
  *   GET https://solid.jobs/public-api/offers/<division>
  *
- * Ported from parent career-ops `providers/solidjobs.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract. Single fixed origin, so the SSRF defence pins hostname to solid.jobs
  * AND requires the /public-api/offers/ path prefix, plus `redirect:'error'`.
  * Divisions: it, engineering, marketing, sales, hr, logistics, finances, other.

--- a/server/lib/sources/successfactors.mjs
+++ b/server/lib/sources/successfactors.mjs
@@ -5,7 +5,7 @@
  * industrials run at their own domains (jobs.zf.com, jobs.schaeffler.com,
  * jobs.hensoldt.net, jobs.sap.com, …) — all served by the same SF RMK backend.
  *
- * Ported from parent career-ops `providers/successfactors.mjs` into the web-ui
+ * Implements the web-ui
  * source contract (rich job objects + `meta` for auto-discovery). The RMK
  * backend exposes a public, no-auth job-list fragment endpoint:
  *   GET {origin}/tile-search-results/?startrow={N}
@@ -25,7 +25,7 @@
 import { fetchText } from '../http-json.mjs';
 import { decodeEntities } from '../html-entities.mjs';
 
-// Hosts detect() auto-claims (the parent's trusted SF/jobs2web hosts). Branded
+// Hosts detect() auto-claims (the trusted SF/jobs2web hosts). Branded
 // RMK portals (jobs.zf.com …) are NOT auto-claimed — they carry an explicit
 // `provider: successfactors` in portals.yml, which bypasses host detection.
 export const SF_HOST_RE = /(?:^|\.)(?:successfactors\.(?:eu|com)|jobs2web\.com)$/i;
@@ -59,7 +59,7 @@ export function assertSuccessfactorsUrl(url) {
 }
 
 /**
- * Parent #2099 (post-v1.22.0): resolve the tenant BASE — origin plus any
+ * Resolve the tenant BASE — origin plus any
  * brand/tenant path prefix. Some holding companies run several acquired
  * brands off one shared RMK instance, disambiguated by a path segment
  * instead of a separate domain (careers.nemetschek.com/Bluebeam/ vs
@@ -217,7 +217,7 @@ export function parseSuccessfactors(html, { jobBase, fallbackCompany = '' } = {}
  * "live but empty" (meituan/tencent idiom). The `startrow` fetch is left
  * uncaught precisely so a transport error propagates. This web-ui port carries
  * only the RMK tile scraper (no CSB JSON fallback), so there is no post-RMK CSB
- * `probe` carve-out to preserve. Dead-board contract (parent v1.25.0 #2379): a
+ * `probe` carve-out to preserve. Dead-board contract: a
  * page-0 failure (nothing ever fetched) THROWS so scan/portal-health record a
  * real failure; a mid-pagination failure after ≥1 successful page keeps the
  * partials already collected (a transient page-N 5xx/404 must NOT discard the
@@ -273,6 +273,5 @@ export async function fetchSuccessfactors(endpoint, opts = {}) {
     startrow += tiles.length;
   }
   // The cap is checked between pages, so the last page can overshoot it.
-  // (parent career-ops parity, #1528)
   return out.slice(0, MAX_JOBS);
 }

--- a/server/lib/sources/tencent.mjs
+++ b/server/lib/sources/tencent.mjs
@@ -2,7 +2,7 @@
  * Tencent careers source — hits the public careers.tencent.com JSON API.
  * Zero-auth, no browser needed.
  *
- * Ported from parent career-ops `providers/tencent.mjs` (#230) into the
+ * Implements the
  * web-ui source contract. Tencent is a single-company board, so it is
  * selected via an explicit `provider: tencent` entry or auto-detected from a
  * careers.tencent.com careers_url. Config comes from the company entry, read

--- a/server/lib/sources/thehub.mjs
+++ b/server/lib/sources/thehub.mjs
@@ -2,7 +2,7 @@
  * The Hub source — board-wide public JSON API (Nordic / EU startups).
  *   GET https://thehub.io/api/v2/jobsandfeatured?page=N&countryCode=EU
  *
- * v2 migration (parent career-ops 6b33fc4 + ae905db): the old `/api/jobs`
+ * v2 migration: the old `/api/jobs`
  * endpoint moved to `/api/v2/jobsandfeatured`, which wraps the list in a
  * `jobs` envelope and no longer carries a per-posting URL or posting date.
  *
@@ -24,8 +24,7 @@
  * Paginated 15/page via `?page=N` (1-indexed); the `jobs.pages` field bounds
  * the loop. Default cap is 3 pages; override via opts.maxPages (clamped to [1, 50]).
  *
- * Ported from parent career-ops `providers/thehub.mjs` — reimplemented to the
- * web-ui source contract (no code lifted).
+ * Reimplemented to the web-ui source contract (no code lifted).
  *
  * Used by the thehub adapter (server/lib/portals/adapters/thehub.mjs).
  */

--- a/server/lib/sources/themuse.mjs
+++ b/server/lib/sources/themuse.mjs
@@ -3,7 +3,7 @@
  *   GET https://www.themuse.com/api/public/jobs?page={n}
  *   Response: { results: [...], page: n, page_count: N }
  *
- * Ported from parent career-ops `providers/themuse.mjs` into the
+ * Implements the
  * web-ui source contract. Fetches up to maxPages pages sequentially.
  *
  * Used by the themuse adapter (server/lib/portals/adapters/themuse.mjs).

--- a/server/lib/sources/tkms.mjs
+++ b/server/lib/sources/tkms.mjs
@@ -16,7 +16,7 @@
  * {origin}/{locale}/job/{slug}/{id} — the slug is cosmetic (a stub resolves the
  * same posting), so we slugify the title.
  *
- * Ported from parent career-ops `providers/tkms.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (rich job objects + `meta`). Host-pinned to jobs.tkmsgroup.com via
  * TKMS_HOST_RE, https only (the POST uses `redirect:'error'`, so a plain-HTTP
  * origin would send cleartext and hard-fail on any HTTPS redirect — reject it

--- a/server/lib/sources/vdab.mjs
+++ b/server/lib/sources/vdab.mjs
@@ -5,7 +5,7 @@
  * title_filter + location_filter + dedup afterwards, so this source
  * over-fetches (recall-first) — same philosophy as arbeitsagentur.mjs.
  *
- * Ported from parent career-ops `providers/vdab.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract (no code lifted). Config comes from the company entry's `vdab:`
  * block, read via `opts.company`:
  *

--- a/server/lib/sources/weworkremotely.mjs
+++ b/server/lib/sources/weworkremotely.mjs
@@ -3,7 +3,7 @@
  * We Work Remotely source — board-wide remote-jobs RSS feed.
  *   GET https://weworkremotely.com/remote-jobs.rss
  *
- * Ported from parent career-ops v1.14.0 `providers/weworkremotely.mjs` into the
+ * Implements the
  * web-ui source contract (rich job objects + `meta` for auto-discovery).
  *
  * The feed is public, no-auth XML, parsed in-process with a tiny tag extractor

--- a/server/lib/sources/workable.mjs
+++ b/server/lib/sources/workable.mjs
@@ -1,8 +1,8 @@
 /**
  * Workable public jobs API wrapper.
  *
- * PRIMARY endpoint (parent career-ops v1.25.0 parity — commit 5ab8425
- * "use the public widget API so large accounts are scanned"):
+ * PRIMARY endpoint (the public widget API, so large accounts are scanned in
+ * full):
  *
  *   GET https://apply.workable.com/api/v1/widget/accounts/<slug>?details=true
  *   → { name, description, jobs: [{ title, shortcode, shortlink, url,
@@ -25,8 +25,8 @@
  * throw as "board unreachable" and an empty array as "board reachable, no
  * matching roles". We never swallow a network/HTTP error into `[]`.
  *
- * HARDENING (parent career-ops parity — commit feabcd4, "harden workable with
- * retry, headers, and serialization"): the widget request carries browser-like
+ * HARDENING (retry, headers, and serialization): the widget request carries
+ * browser-like
  * headers (the shared BROWSER_LIKE_USER_AGENT + accept-language + origin + a
  * per-account referer), retries transient failures (429 / 5xx / network) via the
  * shared `fetchJsonWithRetry`, and is serialized process-wide against
@@ -34,7 +34,7 @@
  * in-flight request at a time avoids self-inflicted rate-limiting. A permanent
  * 4xx is not retried; once the retry budget is spent the error propagates and the
  * dead-board throw fires. (The web-ui source is single-request — it has no
- * markdown fallback — so the parent's give-up-early-on-long-Retry-After branch,
+ * markdown fallback — so a give-up-early-on-long-Retry-After branch,
  * whose only purpose is to fall through to that feed, does not apply here.)
  */
 import { fetchJsonWithRetry, BROWSER_LIKE_USER_AGENT } from '../http-json.mjs';
@@ -42,8 +42,7 @@ import { fetchJsonWithRetry, BROWSER_LIKE_USER_AGENT } from '../http-json.mjs';
 // Browser-like request headers. apply.workable.com sits behind Cloudflare, which
 // can block a generic UA outright; the shared BROWSER_LIKE_USER_AGENT keeps every
 // worked-around source pinned to one Chrome version instead of drifting per file.
-// `referer` is per-account, added in fetchWorkable. Mirrors the parent's
-// WORKABLE_HEADERS.
+// `referer` is per-account, added in fetchWorkable.
 const WORKABLE_HEADERS = {
   'user-agent': BROWSER_LIKE_USER_AGENT,
   accept: 'application/json',
@@ -53,8 +52,8 @@ const WORKABLE_HEADERS = {
 
 // Process-wide serialization: apply.workable.com fronts every tenant on the same
 // host, so this process never needs more than one in-flight request to it at a
-// time. Mirrors the parent's `serialized()` — errors are swallowed off the queue
-// tail so one failed fetch can't wedge every later one.
+// time. Errors are swallowed off the queue tail so one failed fetch can't wedge
+// every later one.
 let workableQueue = Promise.resolve();
 function serialized(fn) {
   const result = workableQueue.then(fn, fn);
@@ -165,7 +164,7 @@ export async function fetchWorkable(apiUrl, opts = {}) {
   if (!slug) throw new Error(`Workable: cannot derive account slug from ${apiUrl}`);
 
   // Build on a hard-coded host and re-assert (defence in depth); `redirect:
-  // 'error'` closes the SSRF-via-redirect vector, matching the parent.
+  // 'error'` closes the SSRF-via-redirect vector.
   const url = assertWorkableUrl(widgetUrlForSlug(slug));
   const referer = `https://apply.workable.com/${slug}/`;
 

--- a/server/lib/sources/workday.mjs
+++ b/server/lib/sources/workday.mjs
@@ -57,7 +57,7 @@ export async function fetchWorkday(apiUrl, opts = {}) {
   // Some tenants front their CXS API with Cloudflare bot management (seen
   // live upstream: geico) that 500s requests missing ordinary browser
   // headers. A real Chrome UA + accept-language + matching origin/referer
-  // clears it without per-tenant config (parent career-ops fix #1813).
+  // clears it without per-tenant config.
   // Derive origin + site from the CXS URL itself:
   //   https://<tenant>.wdN.myworkdayjobs.com/wday/cxs/<tenant>/<site>/jobs
   const headers = {

--- a/server/lib/sources/workingnomads.mjs
+++ b/server/lib/sources/workingnomads.mjs
@@ -2,7 +2,7 @@
  * Working Nomads source — board-wide remote-jobs aggregator feed.
  *   GET https://www.workingnomads.com/api/exposed_jobs/  → JSON array
  *
- * Ported from parent career-ops v1.12.0 `providers/workingnomads.mjs` into the
+ * Implements the
  * web-ui source contract. The en-scanner's title_filter / location_filter gate
  * the returned rows afterwards.
  *

--- a/server/lib/sources/wttj.mjs
+++ b/server/lib/sources/wttj.mjs
@@ -2,7 +2,7 @@
  * Welcome to the Jungle source — queries WTTJ's public Algolia search index
  * (the same one welcometothejungle.com's jobs UI calls).
  *
- * Ported from parent career-ops `providers/wttj.mjs` into the web-ui source
+ * Implements the web-ui source
  * contract. Two-host flow, both HTTPS-only + host-pinned:
  *   1. GET https://www.welcometothejungle.com/api/env → a `window.env = {…}`
  *      payload carrying the public Algolia application id + client search key.
@@ -98,8 +98,8 @@ export function parseEnvPayload(text) {
 }
 
 /**
- * Format a salary string from a hit's yearly fields, matching the parent's
- * semantics: trust salary_maximum only when salary_period is 'yearly',
+ * Format a salary string from a hit's yearly fields: trust salary_maximum only
+ * when salary_period is 'yearly',
  * otherwise keep just the annualized minimum. Returns '' when no salary is set.
  * @param {any} h
  * @returns {string}

--- a/server/lib/states.mjs
+++ b/server/lib/states.mjs
@@ -1,12 +1,11 @@
 /**
- * Canonical application states — parent `templates/states.yml` port (v1.128.0).
+ * Canonical application states — loaded from `templates/states.yml` (v1.128.0).
  *
  * `templates/states.yml` is the SINGLE SOURCE OF TRUTH for the application
  * status vocabulary: career-ops (the writer) and this dashboard (a reader) both
- * consult it. Ported from the parent's `web/src/lib/core/states.ts` so the
- * web-ui reads the list LIVE instead of hardcoding a whitelist that had to be
- * manually re-synced every parent release (e.g. 'Hired' in v1.118.0). Reads are
- * always safe per the parent-project contract; `js-yaml` is already a dep.
+ * consult it. The web-ui reads the list LIVE instead of hardcoding a whitelist
+ * that had to be manually re-synced every release (e.g. 'Hired' in v1.118.0).
+ * Reads are always safe here; `js-yaml` is already a dep.
  *
  * The FALLBACK below is a last resort if the file is unreadable (fresh clone,
  * or a CI-isolated test whose CAREER_OPS_ROOT has no templates/). It is kept
@@ -39,9 +38,9 @@ let cache = null;
 /**
  * Read the canonical states from `templates/states.yml`, falling back to the
  * built-in list if the file is missing or malformed. A SUCCESSFUL read is
- * memoized per process (the parent file does not change under a running
+ * memoized per process (the states file does not change under a running
  * server; matches how PATHS resolves once — see tests/paths-once.test.mjs); a
- * FALLBACK is NOT cached, so a transiently-unavailable parent recovers on the
+ * FALLBACK is NOT cached, so a transiently-unavailable file recovers on the
  * next call instead of being pinned for the process lifetime.
  * @returns {CanonicalState[]}
  */
@@ -51,7 +50,7 @@ export function readCanonicalStates() {
   // read: a check-then-read pair is both a TOCTOU race (js/file-system-race)
   // and a redundant stat. ENOENT = the expected fresh-clone / CI-isolated case
   // (stay quiet); any other read error, or a present-but-empty parse, is drift
-  // worth a one-line warn so ops can see the tracker diverge from the parent.
+  // worth a one-line warn so ops can see the tracker diverge from the canonical list.
   let raw = null;
   try {
     raw = readFileSync(PATHS.statesYml, 'utf8');

--- a/server/lib/store.mjs
+++ b/server/lib/store.mjs
@@ -2,7 +2,7 @@
  * Read-side helpers for project files plus a one-time bootstrap.
  *
  * Defensive readers — return empty results on missing / unreadable files
- * instead of crashing the server. Keeps the SPA usable when the project
+ * instead of crashing the server. Keeps the SPA usable when career-ops
  * is half-set-up (Health page surfaces the gaps).
  */
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';

--- a/server/lib/store.mjs
+++ b/server/lib/store.mjs
@@ -1,8 +1,8 @@
 /**
- * Read-side helpers for parent-project files plus a one-time bootstrap.
+ * Read-side helpers for project files plus a one-time bootstrap.
  *
  * Defensive readers — return empty results on missing / unreadable files
- * instead of crashing the server. Keeps the SPA usable when the parent
+ * instead of crashing the server. Keeps the SPA usable when the project
  * is half-set-up (Health page surfaces the gaps).
  */
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';

--- a/server/lib/text-key.mjs
+++ b/server/lib/text-key.mjs
@@ -1,7 +1,6 @@
 // @ts-check
 /**
- * Unicode-aware text key for dedup / matching (parent career-ops
- * `tracker-parse.mjs::normalizeTextKey`, #2569 / #2587 / #2667).
+ * Unicode-aware text key for dedup / matching.
  *
  * The web-ui equivalents used to key company and role titles with an ASCII-only
  * strip (`[^a-z0-9]` / plain `.toLowerCase()`). That silently erased non-Latin

--- a/server/lib/trust-validator.mjs
+++ b/server/lib/trust-validator.mjs
@@ -2,8 +2,7 @@
 /**
  * trust-validator.mjs — lightweight trust validation for scanned job postings.
  *
- * Ported from parent career-ops v1.13.0 `providers/_trust-validator.mjs`. Enriches
- * each job with a trust score (0-100), flags (string[]), and level
+ * Enriches each job with a trust score (0-100), flags (string[]), and level
  * ('high'|'medium'|'low'). It NEVER drops a job — it only annotates, so the SPA
  * can surface a badge and the user decides. Off by default; opt in via
  * `portals.yml::trust_filter`.


### PR DESCRIPTION
## What & why

Comment/docstring-only sweep across `server/lib` + `public/js`: reword ~250 comment lines that referenced where the code originated, so the technical explanation stays but the origin note is gone. **Zero behaviour change** — 160 files, comments/docs only (verified: code byte-identical after stripping comments), full suite green (**2470**).

## Scope decisions
- **Removed** (provenance): "Ported from parent…", "parent parity", "parent #NNNN", "(parent career-ops vX.Y)", "(parent web/ port #N)".
- **Kept**: user-facing strings (i18n dictionary values, `t()` fallbacks, API error messages that tell the user which companion scripts they need), DOM "parent" references, web-ui's own release/workstream markers (v1.x / WS4 / FIX-3), and **internal** parity notes (i18n key parity ×17, cross-adapter contract parity).
- **`career-ops` may still be named in source comments** where path resolution genuinely depends on the companion project (env-config, paths, batch, content, store) — that's functional disambiguation, not provenance. The rule: *product/CHANGELOG/README surfaces never name the parent; source comments may when the code's behaviour depends on it.*
- Recorded the **upstream mirror inventory** in `.claude/PROJECT-CONTEXT.md` (centralized on purpose) so future syncs still know which files track upstream now that the in-code markers are gone.

## No version bump
Pure internal cleanup — no user-facing change, so no version bump / CHANGELOG / banner (a "we cleaned up comments" release would misrepresent it). CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)