### PR TITLE
test(cv-studio): cover verify-facts unparseable / no-verdict branches (#252 review)

### DIFF
--- a/tests/cv-studio-verify-facts-route.test.mjs
+++ b/tests/cv-studio-verify-facts-route.test.mjs
@@ -68,6 +68,27 @@ test('empty text is a 400', async () => {
   assert.equal(r.status, 400);
 });
 
+// These two rewrite the fake via writeFake, so they must stay ABOVE the
+// script-absent test below (which rmSync's it). node:test runs a file's
+// top-level tests sequentially, so the order holds.
+test('unparseable stdout fails soft to {available:false, script-error}', async () => {
+  writeFake(`console.log('this is not json at all');`);
+  const r = await post('anything');
+  const d = await r.json();
+  assert.equal(r.status, 200);
+  assert.equal(d.available, false);
+  assert.equal(d.reason, 'script-error');
+});
+
+test('JSON without a verdict field fails soft to {available:false, script-error}', async () => {
+  writeFake(`console.log(JSON.stringify({ notAVerdict: true }));`);
+  const r = await post('anything');
+  const d = await r.json();
+  assert.equal(r.status, 200); // fails soft, never a 5xx
+  assert.equal(d.available, false);
+  assert.equal(d.reason, 'script-error');
+});
+
 test('fails soft to {available:false} when the script is absent', async () => {
   rmSync(join(root, 'verify-cv-facts.mjs'), { force: true });
   const r = await post('anything');


### PR DESCRIPTION
Closes the coverage gap the PR #252 review flagged: the verify-facts handler's fail-soft branches (`!data || typeof data.verdict !== 'string'`) were untested. Adds two cases — unparseable stdout and JSON without a verdict field — both asserting `{available:false, reason:'script-error'}` at HTTP 200 (fails soft, never 5xx). Test-only; no source change, no version bump. Suite +2 → 2512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)