### PR TITLE
chore(comments): drop origin-provenance from code comments (R0.5)

### DIFF
--- a/server/lib/discover-ats.mjs
+++ b/server/lib/discover-ats.mjs
@@ -10,8 +10,7 @@
  * fixed-host API endpoint, and each adapter's `fetch()` normalizes the board's
  * jobs — we just count them.
  *
- * Ported from the parent CLI (career-ops/discover-ats.mjs) — the CORE resolve
- * logic only (slug generation, per-vendor probe-URL shape, and the "board exists
+ * The CORE resolve logic only (slug generation, per-vendor probe-URL shape, and the "board exists
  * AND lists ≥1 job" decision). The CLI shell (arg parsing, YAML batch I/O,
  * concurrency tuning, portals.yml write) is intentionally left out; the write
  * lives in the route via a small text splice, and the parent's `providers/*`
@@ -142,7 +141,7 @@ export function isDuplicateCompany(existing, name, careersUrl) {
 }
 
 /**
- * Quote a YAML scalar only when it needs it (ported from the parent). Bare
+ * Quote a YAML scalar only when it needs it. Bare
  * values stay bare to match the hand-written portals.yml style.
  * @param {string} value
  */
@@ -154,8 +153,8 @@ export function yamlScalar(value) {
 }
 
 /**
- * Render one board as a portals.yml `tracked_companies` entry snippet (ported
- * from the parent, trimmed to the web-ui adapter contract). Leads with a newline
+ * Render one board as a portals.yml `tracked_companies` entry snippet (trimmed
+ * to the web-ui adapter contract). Leads with a newline
  * so it slots cleanly against surrounding entries. careers_url alone is enough
  * for the web-ui scanner to detect the vendor, so no `api:` line is emitted;
  * `provider:` is written when known for readability.

--- a/server/lib/liveness-api.mjs
+++ b/server/lib/liveness-api.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 /**
  * liveness-api.mjs — zero-token, zero-browser liveness check for ATS-hosted
- * job postings (ported from the parent career-ops liveness-api.mjs).
+ * job postings.
  *
  * Many postings live on ATS platforms (Greenhouse, Lever, Ashby, Workday,
  * SmartRecruiters) that expose a public JSON endpoint. We confirm whether a

--- a/server/lib/liveness-core.mjs
+++ b/server/lib/liveness-core.mjs
@@ -1,6 +1,5 @@
 /**
- * liveness-core.mjs — PURE liveness classifier (ported from the parent
- * career-ops liveness-core.mjs). Zero-dep, no I/O, deterministic.
+ * liveness-core.mjs — PURE liveness classifier. Zero-dep, no I/O, deterministic.
  *
  * Given a fetched page's { status, requestedUrl, finalUrl, bodyText,
  * applyControls }, decide whether the posting is still `active`, `expired`,

--- a/server/lib/parsers.mjs
+++ b/server/lib/parsers.mjs
@@ -88,7 +88,7 @@ export function parseMarkdownTable(text) {
  * variant headers back onto the canonical field name before the row object is
  * built, so every downstream consumer sees the same field names.
  *
- * Mirrors the parent career-ops shared alias table (`tracker-aliases.json`):
+ * The header-alias table covers:
  * identity entries for the canonical labels plus the ES `empresa`→company /
  * `puesto`→role pairs, extended conservatively with the remaining well-known,
  * unambiguous Spanish translations and English variants. Kept deliberately
@@ -112,8 +112,8 @@ export const HEADER_ALIASES = {
   notes: 'notes',
   url: 'url',
   // Spanish localized headers.
-  empresa: 'company', // from the parent shared alias table
-  puesto: 'role', // from the parent shared alias table
+  empresa: 'company', // ES header alias
+  puesto: 'role', // ES header alias
   estado: 'status',
   fecha: 'date',
   enlace: 'url',

--- a/tests/discover-ats-resolver.test.mjs
+++ b/tests/discover-ats-resolver.test.mjs
@@ -116,7 +116,7 @@ test('discoverAts: blank name → no probing, empty results', async () => {
   assert.equal(calls, 0, 'must not fetch for a blank company name');
 });
 
-// ── portals.yml write helpers (ported from the parent CLI) ──────────────
+// ── portals.yml write helpers ────────────────────────────────────────
 test('renderPortalEntry: name + careers_url + provider + enabled, no api line', () => {
   const s = renderPortalEntry({ name: 'Adyen', careers_url: 'https://job-boards.greenhouse.io/adyen', provider: 'greenhouse' });
   assert.match(s, /^\n {2}- name: Adyen\n/);

--- a/tests/html-entities.test.mjs
+++ b/tests/html-entities.test.mjs
@@ -1,4 +1,4 @@
-// Shared HTML-entity decoder — parity with the parent's providers/_html-entities.mjs.
+// Shared HTML-entity decoder.
 //
 // Regression for the crash class the parent fixed (#2150): the bare
 // `Number.isFinite(code) ? String.fromCodePoint(code) : m` guard in

--- a/tests/job-facets.test.mjs
+++ b/tests/job-facets.test.mjs
@@ -1,5 +1,5 @@
 /**
- * job-facets.js — zero-token job facet derivations (ported from parent inbox.ts).
+ * job-facets.js — zero-token job facet derivations.
  * Loaded in a synthetic window (same pattern as cv-diagnostics.test.mjs).
  */
 import { test } from 'node:test';
@@ -35,7 +35,7 @@ test('seniorityFromTitle: an explicit modifier wins over a management word (prec
 test('seniorityFromTitle: generic IC role → mid, no keyword at all → null (parent default)', () => {
   // A plain IC role with no ladder word sits in the broad middle.
   assert.equal(JF.seniorityFromTitle('Software Engineer'), 'mid');
-  // A title with none of the recognised words → null (untagged), mirroring parent.
+  // A title with none of the recognised words → null (untagged).
   assert.equal(JF.seniorityFromTitle('Chef de Cuisine'), null);
 });
 

--- a/tests/location-filter.test.mjs
+++ b/tests/location-filter.test.mjs
@@ -1,9 +1,8 @@
 /**
- * v1.33.0 (WS4) — `buildLocationFilter` parity with parent
- * career-ops 1.8.0 scan.mjs (#570).
+ * v1.33.0 (WS4) — `buildLocationFilter` location semantics (#570).
  *
  * Locks the exact semantics so a future refactor can't drift from the
- * parent's `portals.yml::location_filter` behaviour. web-ui's
+ * the `portals.yml::location_filter` behaviour. web-ui's
  * en-scanner / ru-scanner run in-process (don't shell out to the
  * parent's scan.mjs), so this shared module IS the contract.
  */

--- a/tests/modes-endpoints.test.mjs
+++ b/tests/modes-endpoints.test.mjs
@@ -60,8 +60,8 @@ async function postMode(slug, body = {}) {
   return { status: res.status, body: await res.json() };
 }
 
-// v1.70.0 — `cover` (cover-letter mode) ported from the parent; the
-// parametrized loop below asserts it is allowlisted and assembles like the rest.
+// v1.70.0 — `cover` (cover-letter mode); the parametrized loop below asserts
+// it is allowlisted and assembles like the rest.
 const ALL_SLUGS = ['project', 'training', 'followup', 'batch', 'contacto', 'interview-prep', 'patterns', 'cover'];
 
 for (const slug of ALL_SLUGS) {

--- a/tests/sources-ats-providers.test.mjs
+++ b/tests/sources-ats-providers.test.mjs
@@ -1,7 +1,7 @@
 /**
- * Tests for the per-tenant ATS sources ported from parent career-ops v1.13.0:
- * BambooHR, Breezy HR, Comeet, Personio, plus the long-standing parent providers
- * Recruitee and SolidJobs (added to web-ui in v1.76.0 for full source parity).
+ * Tests for the per-tenant ATS sources:
+ * BambooHR, Breezy HR, Comeet, Personio, plus the long-standing
+ * Recruitee and SolidJobs sources (added to web-ui in v1.76.0).
  *
  * CI-isolated: HTTP is never hit; a fake fetchImpl is injected and `opts.company`
  * is passed explicitly the same way en-scanner does. Each block covers parse +

--- a/tests/sources-config-providers.test.mjs
+++ b/tests/sources-config-providers.test.mjs
@@ -1,6 +1,6 @@
 /**
- * Tests for the config-driven scanner sources ported from parent career-ops
- * v1.12.0: IBM, Arbeitsagentur, Glints, Jobstreet.
+ * Tests for the config-driven scanner sources:
+ * IBM, Arbeitsagentur, Glints, Jobstreet.
  *
  * These read per-entry config from `opts.company.<provider>` and POST / paginate
  * against public JSON APIs. CI-isolated: HTTP is never hit; a fake fetchImpl is

--- a/tests/sources-echojobs.test.mjs
+++ b/tests/sources-echojobs.test.mjs
@@ -6,8 +6,8 @@
  * roles indistinguishable from remote ones: a `location_filter.block:["Hybrid"]`
  * rule became unmatchable and hybrid roles slipped through a remote-only filter.
  *
- * Ported from the parent career-ops fix (`providers/echojobs.mjs` #2258),
- * adapted to the web-ui rich job shape (`location` + `isRemote` + `workplaceType`):
+ * Covers hybrid-role location handling for the web-ui rich job shape
+ * (`location` + `isRemote` + `workplaceType`):
  *   - a hybrid role with a city keeps the city and gains " · Hybrid"
  *   - a placeless hybrid role becomes a bare "Hybrid"
  *   - a placeless remote role stays "Remote"

--- a/tests/sources-icims.test.mjs
+++ b/tests/sources-icims.test.mjs
@@ -1,5 +1,5 @@
 /**
- * iCIMS source + adapter — ported from parent career-ops `providers/icims.mjs`.
+ * iCIMS source + adapter.
  * Targets the classic iCIMS hosted-portal search pages at
  * `careers-<tenant>.icims.com` (DISTINCT from the jibeapply source). Public,
  * zero-auth HTML search fragment, host-pinned per tenant. CI-isolated:
@@ -18,8 +18,7 @@ import { icimsAdapter } from '../server/lib/portals/adapters/icims.mjs';
 const ORIGIN = 'https://careers-acmefreight.icims.com';
 const ENDPOINT = icimsSearchUrl(ORIGIN); // https://careers-acmefreight.icims.com/jobs/search?ss=1&in_iframe=1
 
-// Search-results fixture (snippets ported from the parent's
-// tests/fixtures/icims-search-page.html): a card with a rendered location and
+// Search-results fixture: a card with a rendered location and
 // an entity-bearing title, a themed second card, and a foreign-host card that
 // must be dropped by the origin pin.
 const FIXTURE = `<div class="iCIMS_MainWrapper iCIMS_ListingsPage">

--- a/tests/sources-join.test.mjs
+++ b/tests/sources-join.test.mjs
@@ -1,7 +1,6 @@
 /**
  * JOIN (join.com) source + adapter — CI-isolated tests (fake fetchImpl, no
- * network, no parent-project dependency). Ported from parent career-ops
- * `tests/providers/join.test.mjs`, adapted to the web-ui source contract:
+ * network, no parent-project dependency), adapted to the web-ui source contract:
  * rich normalized job objects, host-pinned `fetchText` fetches with
  * `redirect:'error'`, and the successfactors-style dead-board contract (throw
  * on a page-0 failure, keep partials on a later-page failure).

--- a/tests/sources-parity-v1118a.test.mjs
+++ b/tests/sources-parity-v1118a.test.mjs
@@ -2,7 +2,7 @@
  * v1.118 parent-parity sources (batch A) — csod / phenom / radancy.
  * Fetch/parse with a stubbed transport (no network), host-pinning, meta shape
  * for the scan dropdown, and adapter matches()/buildEndpoint(). Fixtures
- * adapted from the parent career-ops provider tests.
+ * adapted to the web-ui provider contract.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/sources-parity-v1118c.test.mjs
+++ b/tests/sources-parity-v1118c.test.mjs
@@ -2,7 +2,7 @@
  * v1.118 parent-parity sources — hecklerkoch / rheinmetall / larajobs.
  * Fetch/parse with a stubbed transport (no network), host-pinning, meta shape
  * for the scan dropdown, and adapter matches()/buildEndpoint(). Fixtures are
- * adapted from the parent's tests/providers/{hecklerkoch,rheinmetall,larajobs}.test.mjs.
+ * adapted to the web-ui provider contract for hecklerkoch, rheinmetall, larajobs.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/sources-radancy.test.mjs
+++ b/tests/sources-radancy.test.mjs
@@ -5,7 +5,7 @@
  * the two-markup-generations fix, adapted to the web-ui source contract: the
  * parsers emit rich job objects (not raw {id,title,url,location} records) and
  * the fragment transport is reached via an injected `opts.fetchJson` capability
- * (mirroring the parent's `ctx.fetchJson` gate) rather than a `ctx` object.
+ * (an injected-capability gate) rather than a `ctx` object.
  *
  * Fixtures are trimmed from real responses. Both legacy fixtures keep the
  * sibling <button class="js-save-job-btn" data-job-id="…"> that repeats the job

--- a/tests/sources-remote-feeds.test.mjs
+++ b/tests/sources-remote-feeds.test.mjs
@@ -1,6 +1,6 @@
 /**
- * Tests for the board-wide remote-aggregator sources ported from parent
- * career-ops v1.12.0: RemoteOK, Remotive, Working Nomads.
+ * Tests for the board-wide remote-aggregator sources:
+ * RemoteOK, Remotive, Working Nomads.
  *
  * CI-isolated: HTTP is never hit; a fake fetchImpl is injected.
  */

--- a/tests/sources-successfactors.test.mjs
+++ b/tests/sources-successfactors.test.mjs
@@ -1,6 +1,5 @@
 /**
- * SAP SuccessFactors (RMK) source + adapter — ported from parent career-ops
- * `providers/successfactors.mjs`. Public, zero-auth HTML tile fragment,
+ * SAP SuccessFactors (RMK) source + adapter. Public, zero-auth HTML tile fragment,
  * host-pinned per tenant. CI-isolated: fetchImpl is faked, no network.
  */
 import { test } from 'node:test';

--- a/tests/sources-wttj.test.mjs
+++ b/tests/sources-wttj.test.mjs
@@ -2,8 +2,8 @@
  * Welcome to the Jungle source + adapter tests (CI-isolated, fake fetchImpl).
  * No live network, no parent-project files, no port binding.
  *
- * Ports the meaningful cases from parent career-ops `tests/providers/wttj.test.mjs`,
- * adapted to the 12-field web-ui job shape (salary is a string; isRemote /
+ * Covers the meaningful cases for the 12-field web-ui job shape (salary is a
+ * string; isRemote /
  * workplaceType / id / source added).
  */
 import { test } from 'node:test';


### PR DESCRIPTION
## What

Reword code and test comments that announced where the code was originally adapted from — `"ported from parent…"`, `"parity with parent…"`, `"mirrors the parent…"` — to describe what the code **does** instead, keeping every technical detail. Provenance belongs in commit history, not in shipping comments.

## Surgical, not a blind sweep

Functional runtime references are **kept** — they describe live behavior, not origin:
- the fail-soft `"the parent career-ops … script was not found"` UI strings (users see these),
- the `"relays the parent's analyze-patterns.mjs"` data-source notes,
- the parity-fixture `"mirrors the REAL parent output verbatim"` contract warning.

27 comments reworded across `server/lib` (4 files) + `tests/` (16 files). **Comment-only, zero behavior change, no version bump.**

## Verification

- `npm test` → **2621** pass
- All 20 touched files `node --check` clean
- `grep` for `ported from | parity with parent | mirrors parent` in code comments → **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)