### PR TITLE
test(e2e): unify console-error assertions on one shared benign filter

### DIFF
--- a/tests/console-noise.test.mjs
+++ b/tests/console-noise.test.mjs
@@ -1,0 +1,46 @@
+/**
+ * Unit coverage for the shared benign-console filter (tests/helpers/console-noise.mjs).
+ * It gates every Playwright console-error assertion, so its edges matter:
+ * benign 404s drop, but a real 500 / uncaught exception must survive.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { realConsoleErrors, BENIGN_CONSOLE } from './helpers/console-noise.mjs';
+
+test('drops the favicon/asset 404 noise that flaked the suites', () => {
+  const benign = [
+    'Failed to load resource: the server responded with a status of 404 ()',
+    'Failed to load resource: the server responded with a status of 410 ()',
+    'http://localhost:4317/favicon.ico: Failed to load resource: the server responded with a status of 404 ()',
+    'Failed to load resource: net::ERR_ABORTED',
+  ];
+  assert.deepEqual(realConsoleErrors(benign), []);
+  for (const b of benign) assert.ok(BENIGN_CONSOLE.test(b), `should match: ${b}`);
+});
+
+test('keeps a real 500, a non-404/410 status, and an uncaught exception', () => {
+  const real = [
+    'Failed to load resource: the server responded with a status of 500 ()',
+    // status is 500 even though the URL path contains "404" — must NOT be dropped
+    'http://localhost/api/jobs/404: Failed to load resource: the server responded with a status of 500 ()',
+    'Uncaught TypeError: x is not a function',
+    'ReferenceError: y is not defined',
+  ];
+  assert.deepEqual(realConsoleErrors(real), real);
+});
+
+test('connection-teardown noise survives by default, drops only via `extra`', () => {
+  const errs = ['net::ERR_CONNECTION_REFUSED', 'TypeError: Failed to fetch', 'Uncaught Error: real'];
+  // Default: ERR_CONNECTION_REFUSED / "Failed to fetch" are NOT benign — all survive.
+  assert.deepEqual(realConsoleErrors(errs), errs);
+  // With an opt-in extra pattern, the connection noise drops; the real error stays.
+  assert.deepEqual(
+    realConsoleErrors(errs, /ERR_CONNECTION_REFUSED|Failed to fetch/i),
+    ['Uncaught Error: real'],
+  );
+});
+
+test('tolerates an empty / missing list', () => {
+  assert.deepEqual(realConsoleErrors([]), []);
+  assert.deepEqual(realConsoleErrors(undefined), []);
+});

--- a/tests/e2e-comprehensive.mjs
+++ b/tests/e2e-comprehensive.mjs
@@ -8,6 +8,7 @@
  *     node web-ui/tests/e2e-comprehensive.mjs
  */
 import { chromium } from 'playwright';
+import { realConsoleErrors } from './helpers/console-noise.mjs';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -371,13 +372,15 @@ async function run() {
     console.log('  page errors:');
     pageErrors.forEach((e) => console.log(`    · ${e}`));
   }
-  // Filter out the deliberately-killed connection-banner test errors.
-  const realConsoleErrors = consoleErrors.filter(
-    (l) => !/ERR_CONNECTION_REFUSED|Failed to fetch|connection lost/i.test(l)
+  // Drop benign favicon/asset 404 noise (shared filter) plus this suite's own
+  // deliberately-killed connection errors (passed as `extra`); real errors survive.
+  const realErrors = realConsoleErrors(
+    consoleErrors,
+    /ERR_CONNECTION_REFUSED|Failed to fetch|connection lost/i,
   );
-  if (realConsoleErrors.length) {
+  if (realErrors.length) {
     console.log('  unexpected console errors:');
-    realConsoleErrors.forEach((e) => console.log(`    · ${e}`));
+    realErrors.forEach((e) => console.log(`    · ${e}`));
   }
   process.exit(failures.length === 0 && pageErrors.length === 0 ? 0 : 1);
 }

--- a/tests/helpers/console-noise.mjs
+++ b/tests/helpers/console-noise.mjs
@@ -1,0 +1,32 @@
+/**
+ * Shared benign-console filter for the Playwright suites — one source of truth
+ * so the per-file copies can't drift apart (this benign 404 has flaked several
+ * suites as each grew its own, or no, filter).
+ *
+ * Deliberately narrow so it hides ONLY noise that is never a real client bug:
+ *   - a favicon URL (`favicon.ico`), and
+ *   - a "Failed to load resource" whose HTTP status is exactly 404 or 410
+ *     (anchored to `status of <n>` so a 500 on a URL that merely contains
+ *     "404" is NOT swallowed), and
+ *   - an aborted / empty-response network teardown (`net::ERR_ABORTED`,
+ *     `net::ERR_EMPTY_RESPONSE`) — the request was cancelled, not failed.
+ * A 500 (a genuine server error), any other status, and every uncaught JS
+ * exception all still surface, so the assertion keeps its real value.
+ *
+ * Other connection-teardown noise (a test that deliberately kills a live
+ * connection: ERR_CONNECTION_REFUSED / "Failed to fetch" / "connection lost")
+ * is NOT benign by default — the suite that induces it opts in via `extra`.
+ */
+export const BENIGN_CONSOLE =
+  /favicon\.ico|net::ERR_(?:ABORTED|EMPTY_RESPONSE)|Failed to load resource:.*?status of (?:404|410)\b/i;
+
+/**
+ * Drop benign network noise from a collected console-error list. Pass an
+ * optional NON-GLOBAL `extra` RegExp to also treat suite-specific noise as
+ * benign (e.g. a deliberately-killed connection). Real errors survive.
+ * @param {string[]} errors
+ * @param {RegExp} [extra] must not carry the `g`/`y` flag (stateful lastIndex)
+ * @returns {string[]}
+ */
+export const realConsoleErrors = (errors, extra = null) =>
+  (errors || []).filter((e) => !BENIGN_CONSOLE.test(e) && !(extra && extra.test(e)));

--- a/tests/playwright-forms.mjs
+++ b/tests/playwright-forms.mjs
@@ -15,6 +15,7 @@
  */
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { realConsoleErrors } from './helpers/console-noise.mjs';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
@@ -172,8 +173,7 @@ for (const route of FORM_ROUTES) {
     assert.ok(html.length > 20, `#/${route} rendered empty`);
     // Ignore benign favicon/network noise from unconfigured optional
     // endpoints; fail only on real JS/render errors.
-    const real = errors.filter((e) =>
-      !/favicon|net::ERR|Failed to load resource/i.test(e));
+    const real = realConsoleErrors(errors);
     assert.deepEqual(real, [], `#/${route} console errors: ${real.join(' | ')}`);
     await closePage(page);
   });

--- a/tests/playwright-locale-sweep.mjs
+++ b/tests/playwright-locale-sweep.mjs
@@ -18,6 +18,7 @@
  */
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { realConsoleErrors } from './helpers/console-noise.mjs';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
@@ -109,8 +110,9 @@ for (const lang of I18N_LANGS) {
     }
 
     try { await page.evaluate(() => window.stop()); } catch { /* page gone */ }
-    // Ignore expected network-refused noise from probes to the absent parent.
-    const realErrors = consoleErrors.filter((e) => !/ERR_CONNECTION_REFUSED|Failed to load resource/.test(e));
+    // Ignore expected network-refused noise from probes to the absent parent
+    // (opt-in `extra`), plus the shared benign favicon/404 filter.
+    const realErrors = realConsoleErrors(consoleErrors, /ERR_CONNECTION_REFUSED/i);
     assert.deepEqual(realErrors, [], `[${lang}] console errors: ${realErrors.join(' | ')}`);
     await context.close();
   });

--- a/tests/playwright-scan-filters.mjs
+++ b/tests/playwright-scan-filters.mjs
@@ -16,6 +16,7 @@
  */
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { BENIGN_CONSOLE } from './helpers/console-noise.mjs';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
@@ -75,12 +76,6 @@ after(async () => {
   if (server) { server.closeAllConnections?.(); await new Promise((r) => server.close(r)); }
   delete process.env.CAREER_OPS_ROOT;
 });
-
-// Benign network noise a console-error assertion must NOT flake on: a favicon
-// or lazy asset that 404s / fails to load is not a real client error. Same
-// filter the sibling smoke/forms suites use (v1.207.1) — this file had missed it
-// and flaked on a transient `404 Failed to load resource` on a main-push run.
-const BENIGN_CONSOLE = /favicon|net::ERR|Failed to load resource/i;
 
 // Open #/scan and wait for the canned corpus to render.
 async function openScan() {

--- a/tests/playwright-smoke.mjs
+++ b/tests/playwright-smoke.mjs
@@ -21,6 +21,7 @@
  */
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { realConsoleErrors } from './helpers/console-noise.mjs';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
@@ -47,12 +48,6 @@ function resolvePlaywright() {
 const playwright = resolvePlaywright();
 const SKIP = !playwright;
 
-// Benign network noise a console-error assertion must NOT flake on: a favicon
-// or optional-widget resource that transiently 404s while racing SPA boot is
-// not a JS/render error. Mirrors the filter in playwright-forms.mjs; real JS
-// errors (uncaught exceptions, thrown console.error) still surface.
-const BENIGN_CONSOLE = /favicon|net::ERR|Failed to load resource/i;
-const realConsoleErrors = (errors) => errors.filter((e) => !BENIGN_CONSOLE.test(e));
 
 let server, baseUrl, browser, context;
 

--- a/tests/playwright-widgets.mjs
+++ b/tests/playwright-widgets.mjs
@@ -16,6 +16,7 @@
  */
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { realConsoleErrors } from './helpers/console-noise.mjs';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
@@ -101,7 +102,8 @@ test('Ask-the-docs launcher: opens a chat, closes on Escape, hides on #/docs-ass
   await page.waitForSelector('#content');
   assert.equal(await page.locator('#docs-fab').isVisible(), false, 'launcher must hide on #/docs-assistant');
 
-  assert.deepEqual(errors, [], 'console errors: ' + errors.join(' | '));
+  const real = realConsoleErrors(errors);
+  assert.deepEqual(real, [], 'console errors: ' + real.join(' | '));
   await page.close();
 });
 
@@ -128,6 +130,7 @@ test('Usage HUD: fixed bottom-left, shows tokens · cost per window, collapses',
   await page.waitForSelector('#usage-hud', { timeout: 5000 });
   await page.waitForFunction(() => document.getElementById('usage-hud-body').hidden, null, { timeout: 3000 });
 
-  assert.deepEqual(errors, [], 'console errors: ' + errors.join(' | '));
+  const real = realConsoleErrors(errors);
+  assert.deepEqual(real, [], 'console errors: ' + real.join(' | '));
   await page.close();
 });


### PR DESCRIPTION
## Why

The push-to-main CI for #279 failed on Playwright (`tests/playwright-widgets.mjs`) with:
```
console errors: Failed to load resource: the server responded with a status of 404 ()
```
A transient favicon/lazy-asset 404 — the **same** benign noise that flaked the dashboard tests (v1.207.1) and scan-filters (#278). Each suite carried its own (or no) filter, so the same class of flake kept resurfacing in a new file. Fix the class **and** end the drift.

## What

- **New `tests/helpers/console-noise.mjs`** — one narrow `BENIGN_CONSOLE` regex + `realConsoleErrors(errors, extra?)`. Hides **only**: a `favicon.ico` URL, a `Failed to load resource` whose status is exactly **404/410** (anchored to `status of <n>`, so a 500 on a URL that merely contains `404` is **not** dropped), and an aborted/empty-response teardown. A 500, any other status, and every uncaught JS exception still surface. Other killed-connection noise (`ERR_CONNECTION_REFUSED` / `Failed to fetch`) is opt-in via `extra`.
- **Migrated all six console-error suites** to it: `widgets` + `e2e-comprehensive` (were under-filtered), plus `smoke`, `scan-filters`, `forms`, `locale-sweep` (dropped their broader inline copies that also swallowed 500s). `e2e.mjs` is untouched — it filters *pageErrors*, a different mechanism.
- **New `tests/console-noise.test.mjs`** — 5 cases lock the edges (benign 404 drops; a 500 / a 500-on-a-`/404`-URL / an uncaught exception survive; `extra` opt-in; empty input).

## Verification

- `tests/console-noise.test.mjs` → **4/4** (helper edges)
- `npm run test:e2e:browser` → **99/99**
- `npm run test:e2e:full` (comprehensive) → **23/23**
- `npm test` → **2625** (2621 + the 4 helper cases)
- `grep` for inline benign-console copies in `playwright-*.mjs` → **0**

Test-only, CI-isolated, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)