### PR TITLE
fix(repo): remove a dangling symlink that breaks rsync and the parent's test suite

### DIFF
--- a/.claude/skills/refero-design
+++ b/.claude/skills/refero-design
@@ -1,1 +1,0 @@
-../../.agents/skills/refero-design


### PR DESCRIPTION
`.claude/skills/refero-design` is a tracked symlink to `../../.agents/skills/refero-design` — a path that resolves to `.agents/` at the repo root and **has never existed here**. It arrived in the v1.118.0 parity pack (#114), almost certainly picked up from a machine where the surrounding directory nested differently.

## It is not inert

- **rsync aborts on it mid-transfer** (`stat: No such file or directory`). This silently truncated a deploy today: the server kept running 1.227.5 while the transfer reported success. I only caught it because the version check afterwards disagreed.
- **The parent project's `node test-all.mjs` crashes outright** when a web-ui checkout sits inside its tree — its fixture copy walks the working directory and cannot stat the link.
- Anyone cloning this repo gets a broken link.

## Nothing references it

The only `refero` matches in the repo are the Polish word *preferowany* in `docs/help/pl.md`. It is the sole tracked symlink here; the three real skills (`contributor-pr`, `hermes-bridge`, `parent-sync`) are plain directories that resolve fine:

```
ok:     .claude/skills/contributor-pr
ok:     .claude/skills/hermes-bridge
ok:     .claude/skills/parent-sync
BROKEN: .claude/skills/refero-design
```

If the skill is wanted, it should be committed as real files rather than as a link to a directory outside the repo — happy to do that instead if you have the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)