### PR TITLE
refactor(builtin): drop two symbols the port carried over with nothing to call them

### DIFF
--- a/public/js/lib/scan-results.js
+++ b/public/js/lib/scan-results.js
@@ -9,6 +9,13 @@
  * in-browser by tests/playwright-scan-filters.mjs.
  */
 window.ScanResults = (function () {
+  // NOT i18n keys, and deliberately so: every label here is the job board's own
+  // brand name — "Built In", "hh.ru", "4 Day Week", "a16z Speedrun". A brand
+  // reads the same in all 17 locales, and routing it through I18n.t() would
+  // invite 17 translations of a proper noun. These mirror `meta.label` from the
+  // server registry, which is English for the same reason; the drift between
+  // the two is what tests/scan-fallback-sources.test.mjs gates. Surrounding UI
+  // copy — the dropdown's own label, placeholder and empty state — IS localized.
   const FALLBACK_SOURCES = [
     { value: 'builtin',      label: 'Built In' },
     { value: 'feishu-jobs',  label: 'Feishu Jobs' },

--- a/server/lib/sources/builtin.mjs
+++ b/server/lib/sources/builtin.mjs
@@ -89,12 +89,14 @@ export const meta = {
 const DEFAULT_HOST = 'builtin.com';
 const DEFAULT_MAX_PAGES = 3;  // builtin orders newest-first; a few pages = recent roles
 const HARD_MAX_PAGES = 25;    // backstop against a misconfigured entry
-const RETRY_POLICY = { retries: 2, baseDelayMs: 500, maxDelayMs: 8_000 };
 
 // SSRF allowlist. Keys are the accepted spellings, values the CANONICAL host to
-// request. The bare (www-less) market hosts 301 to www and we fetch with
-// redirect:'error', so a bare spelling must be rewritten here rather than
-// failing the fetch. builtinchicago is .org, not .com — not a typo.
+// request. Which spelling is canonical DIFFERS PER BOARD, which is why this is
+// a map and not a "prepend www" rule: the bare market hosts 301 to www
+// (builtinseattle.com -> www.builtinseattle.com) but the national board goes the
+// other way (www.builtin.com -> builtin.com). We fetch with redirect:'error', so
+// the non-canonical spelling must be rewritten here rather than failing the
+// fetch. builtinchicago is .org, not .com — not a typo.
 const HOSTS = new Map([
   ['builtin.com', 'builtin.com'],
   ['www.builtin.com', 'builtin.com'],
@@ -438,19 +440,6 @@ export function readConfig(entry) {
 }
 
 /**
- * Narrow the per-base page cap by ctx.maxPages when the caller is only probing
- * (verify-portals.mjs's health check passes 1).
- *
- * @param {number} entryMax
- * @param {any} ctx
- * @returns {number}
- */
-function effectiveMaxPages(entryMax, ctx) {
-  const hint = Number(ctx?.maxPages);
-  return Number.isFinite(hint) && hint > 0 ? Math.min(entryMax, Math.floor(hint)) : entryMax;
-}
-
-/**
  * `parseSalary` yields `{ min, max }` in whole dollars (the shape the parent's
  * own filters consume); web-ui's job contract carries `salary` as a DISPLAY
  * STRING, so it is formatted here rather than leaking an object into the
@@ -471,8 +460,16 @@ function formatSalary(band) {
  *
  * web-ui contract: the adapter hands us the resolved endpoint and the company
  * entry; everything the parent read off `entry` is read off `company` here, and
- * the parent's retrying `ctx.fetchText` becomes web-ui's `fetchText` with an
- * injectable `fetchImpl` so the suite runs with no network.
+ * the parent's `ctx.fetchText` becomes web-ui's `fetchText` with an injectable
+ * `fetchImpl` so the suite runs with no network.
+ *
+ * The parent's RETRIES are deliberately NOT carried over. web-ui's `fetchText`
+ * makes exactly one attempt, and no other source here retries either — the
+ * `fetchJsonWithRetry` helper in http-json.mjs has zero callers among the 90.
+ * Built In retrying alone would make one source behave unlike every other, and
+ * a scan that silently takes three times as long to fail is worse than one that
+ * reports the failure. If retries are ever wanted, they belong in the shared
+ * fetch layer for all sources, not smuggled in per-source.
  *
  * @param {string} _url unused — the page URLs are built per query/category below
  * @param {{ fetchImpl?: Function, signal?: AbortSignal, company?: object }} [opts]


### PR DESCRIPTION
CodeQL flagged `RETRY_POLICY` and `effectiveMaxPages` as unused on #330. Both findings are real — and each one hid a claim that was not true of this repo.

## `RETRY_POLICY`

It configured the parent's retrying `ctx.fetchText`. web-ui's `fetchText` makes **exactly one attempt**, and the doc comment directly below it read *"the parent's retrying `ctx.fetchText` becomes web-ui's `fetchText`"* — implying a parity that does not exist.

Checked before deleting rather than assuming: `fetchJsonWithRetry` **does** exist in `http-json.mjs`, so the mechanism is there. It has **zero callers among the 90 sources**. No source here retries. Built In retrying alone would make one source behave unlike every other, and a scan that silently takes three times as long to fail is worse than one that reports the failure. The comment now says that outright, and says where retries would belong if they are ever wanted — the shared fetch layer, for all sources.

## `effectiveMaxPages`

It narrowed the page cap by `ctx.maxPages` for a probing caller. web-ui's fetch contract has no `ctx` at all, and the one probe script here (`scripts/portals-health-check.mjs`) fetches URLs directly without going through adapters. Nothing could ever have called it.

## Also corrected while in the file

The `HOSTS` comment said bare market hosts 301 to `www`. True for the markets — but the national board redirects the **other way**. Verified live against all four spellings:

| host | result |
|---|---|
| `builtin.com` | 200 |
| `www.builtin.com` | 301 → `https://builtin.com/jobs` |
| `builtinseattle.com` | 301 → `https://www.builtinseattle.com/jobs` |
| `www.builtinseattle.com` | 200 |

That is exactly why `HOSTS` is an alias→canonical **map** and not a prepend-`www` rule, and why `assertHost` demands a fixed point of it. The comment now carries both directions.

## The i18n finding on #330

An AI review called the four new `FALLBACK_SOURCES` labels a blocker for bypassing `I18n.t()`. They are not. **All 90** entries are the boards' own brand names — `Built In`, `hh.ru`, `4 Day Week`, `a16z Speedrun` — none is localized in any of the 17 locales, and translating a proper noun would be wrong. They mirror `meta.label` from the server registry, which is English for the same reason, and the drift between the two is gated by `tests/scan-fallback-sources.test.mjs`. A comment now records this so the next reader reaches the same conclusion without re-deriving it. The surrounding UI copy — the dropdown's label, placeholder and empty state — **is** localized.

## Verification

**No behaviour change.** `npm run test:ci` — **2956 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)